### PR TITLE
150 fix ci on deploy step

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -79,5 +79,5 @@ cypress
 # Vido
 **/*.stories.ts
 **/*.story.vue
-vidos.config.ts
+# vidos.config.ts
 vidos-config.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,13 @@ vidos.config.ts
 ### Node template
 
 # Yarn v2
+.pnp.*
 .yarn/*
-!.yarn/releases
+!.yarn/patches
 !.yarn/plugins
+!.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-.pnp.*
 
 # Logs
 /logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN yarn install
 
 COPY --link . .
 
+RUN yarn build-config
 RUN yarn build
 
 # Run
@@ -28,5 +29,6 @@ FROM base
 ENV PORT=$PORT
 
 COPY --from=build /src/.output /src/.output
+COPY --from=build /src/vidos-config.json /src/vidos-config.json
 
 CMD [ "node", ".output/server/index.mjs" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        NODE_VERSION: 18-alpine3.17
+        NODE_VERSION: 18.19.0
     # restart: unless-stopped
     ports:
       - '3000:3000'


### PR DESCRIPTION
 Why do we need to generate fixtures on Deploy ?

```bash
ci.yml - Line 166

- ruby poi_explode.rb cypress/fixtures/teritorio/references/pois.geojson
```

Why this uncomment here ? Can’t we leave the command uncommented ?

```bash
docker-compose.yml - Line 9

sed -i "s/# restart: unless-stopped/restart: unless-stopped/"
```

I think we could remove:
```bash
touch vidos-config.json
```
as it is generated by `yarn postinstall` right after a `yarn install`.