### PR TITLE
128 list add category name in page title

### DIFF
--- a/components/PoisList/PoisList.vue
+++ b/components/PoisList/PoisList.vue
@@ -76,6 +76,9 @@ export default defineNuxtComponent({
     categoryId() {
       this.pois = undefined
 
+      // Send new categoryId to parent in order to update meta title
+      this.$emit('categoryUpdate', this.categoryId)
+
       // Change history directly to avoid resetup the page with this.$router.push
       history.pushState({}, '', `/category/${this.categoryId}`)
 

--- a/pages/category/[id].vue
+++ b/pages/category/[id].vue
@@ -90,8 +90,6 @@ export default defineNuxtComponent({
         fetchPoiByCategoryId,
       ])
 
-    useHead(headerFromSettings(settings.value))
-
     return {
       config,
       settings,
@@ -117,6 +115,19 @@ export default defineNuxtComponent({
     this.globalConfig = this.config
     if (this.menuItems)
       menuStore().fetchConfig(this.menuItems)
+
+    // Fetching category by ID
+    // TODO: Has to be done in setup() but menuItems is touched in created() hook
+    const category = menuStore().getCurrentCategory(useRoute().params.id as string)
+    if (!category) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: 'Category Not Found',
+      })
+    }
+
+    this.settings.themes[0].title = category.category.name
+    useHead(headerFromSettings(this.settings))
 
     this.globalSettings = this.settings
     this.globalContents = this.contents

--- a/pages/category/[id].vue
+++ b/pages/category/[id].vue
@@ -7,7 +7,7 @@ import { definePageMeta } from '#imports'
 import PoisList from '~/components/PoisList/PoisList.vue'
 import type { ContentEntry } from '~/lib/apiContent'
 import { getContents } from '~/lib/apiContent'
-import type { MenuItem } from '~/lib/apiMenu'
+import type { ApiMenuCategory, MenuItem } from '~/lib/apiMenu'
 import { getMenu } from '~/lib/apiMenu'
 import type { ApiPois } from '~/lib/apiPois'
 import { getPoiByCategoryId } from '~/lib/apiPois'
@@ -116,19 +116,6 @@ export default defineNuxtComponent({
     if (this.menuItems)
       menuStore().fetchConfig(this.menuItems)
 
-    // Fetching category by ID
-    // TODO: Has to be done in setup() but menuItems is touched in created() hook
-    const category = menuStore().getCurrentCategory(useRoute().params.id as string)
-    if (!category) {
-      throw createError({
-        statusCode: 404,
-        statusMessage: 'Category Not Found',
-      })
-    }
-
-    this.settings.themes[0].title = category.category.name
-    useHead(headerFromSettings(this.settings))
-
     this.globalSettings = this.settings
     this.globalContents = this.contents
     this.globalTranslations = this.propertyTranslations
@@ -144,6 +131,26 @@ export default defineNuxtComponent({
 
   mounted() {
     this.locale = this.$i18n.locale
+    this.handleCategoryUpdate(useRoute().params.id as string)
+  },
+  methods: {
+    getCategory(categoryId: string): ApiMenuCategory {
+      // Fetching category by ID
+      // TODO: Has to be done in setup() but menuItems is touched in created() hook
+      const category = menuStore().getCurrentCategory(categoryId)
+      if (!category) {
+        throw createError({
+          statusCode: 404,
+          statusMessage: 'Category Not Found',
+        })
+      }
+      return category
+    },
+    handleCategoryUpdate(categoryId: number | string) {
+      const category = this.getCategory(categoryId.toString())
+      this.settings.themes[0].title = category.category.name
+      useHead(headerFromSettings(this.settings))
+    },
   },
 })
 </script>
@@ -155,6 +162,7 @@ export default defineNuxtComponent({
     :initial-category-id="parseInt(id)"
     :initial-pois="pois"
     class="page-index"
+    @category-update="handleCategoryUpdate"
   />
 </template>
 

--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -63,6 +63,16 @@ export const menuStore = defineStore('menu', {
           ) as ApiMenuCategory[])
     },
 
+    getCurrentCategory: (state: State): (categoryId: string) => ApiMenuCategory | undefined => {
+      return (categoryId) => {
+        return state.menuItems === undefined
+          ? undefined
+          : Object.values(state.menuItems).find(
+            menuItem => menuItem.id.toString() === categoryId,
+          ) as ApiMenuCategory
+      }
+    },
+
     selectedCategories: (state: State): ApiMenuCategory[] | undefined => {
       return state.menuItems === undefined
         ? undefined


### PR DESCRIPTION
I think we have an anti-pattern about how data is fetch.
It would be better to do data fetching on page level and then propagate them through props or store (in order to avoid props drilling in case we have too much depth between page and last component).

Components would be used for UI only, all the logic resides on higher level. It will give us more scalability and easy of maintenance. As of today we have data fetching a bit everywhere which make it hard to understand and brings rendering issues.

I think we have to think Components as dumb pieces of code, which renders a small piece of layout with the data given in props.