### PR TITLE
Fix category selector with undefined menuItem.category from API.

### DIFF
--- a/components/Home/Embedded.vue
+++ b/components/Home/Embedded.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { FitBoundsOptions } from 'maplibre-gl'
-import { mapActions } from 'pinia'
+import { mapActions, mapState } from 'pinia'
 
 import { defineNuxtComponent, useRequestHeaders } from '#app'
 import HomeMixin from '~/components/Home/HomeMixin'
@@ -26,6 +26,7 @@ export default defineNuxtComponent({
   mixins: [HomeMixin],
 
   computed: {
+    ...mapState(menuStore, ['menuItems']),
     fitBoundsPaddingOptions(): FitBoundsOptions['padding'] {
       return {
         top: 100,
@@ -146,7 +147,7 @@ export default defineNuxtComponent({
           :boundary-area="boundaryArea || settings.polygon.data"
         />
         <CategorySelector
-          :menu-items="Object.values(apiMenuCategory || {})"
+          :menu-items="menuItems || []"
           label="categorySelector.placeholderAdd"
           class="tw-p-4 tw-absolute tw-z-1 tw-w-full"
           @category-change="onMenuChange"

--- a/components/PoisList/PoisList.vue
+++ b/components/PoisList/PoisList.vue
@@ -54,12 +54,10 @@ export default defineNuxtComponent({
   },
 
   computed: {
-    ...mapState(menuStore, ['apiMenuCategory']),
+    ...mapState(menuStore, ['menuItems']),
 
     category(): ApiMenuCategory | undefined {
-      return Object.values(this.apiMenuCategory || {}).find(
-        menuItem => menuItem.id === this.categoryId,
-      )
+      return (this.menuItems || {})[this.categoryId] as ApiMenuCategory
     },
 
     fields(): FieldsListItem[] {
@@ -121,7 +119,7 @@ export default defineNuxtComponent({
     </template>
     <template #body>
       <CategorySelector
-        :menu-items="apiMenuCategory || []"
+        :menu-items="menuItems || []"
         :category-id="categoryId"
         @category-change="onMenuChange"
       />

--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -59,7 +59,7 @@ export const menuStore = defineStore('menu', {
       return state.menuItems === undefined
         ? undefined
         : (Object.values(state.menuItems).filter(
-            menuItem => menuItem.category !== undefined,
+            menuItem => !!menuItem.category,
           ) as ApiMenuCategory[])
     },
 


### PR DESCRIPTION
The old WP API fill `menuItem.category` with `null` when is not a category. The new Elasa API omit `menuItem.category` then is undefined.

The original store with WP API filter nothing. So fix the sotre filter. Than, use the full menu in category.