### PR TITLE
Move composable in setup function

### DIFF
--- a/components/PoisList/Actions.vue
+++ b/components/PoisList/Actions.vue
@@ -14,6 +14,7 @@ export default defineNuxtComponent({
     IconsBar,
     IconButton,
   },
+
   props: {
     categoryId: {
       type: Number,
@@ -23,6 +24,14 @@ export default defineNuxtComponent({
       type: String as PropType<string>,
       required: true,
     },
+  },
+
+  setup() {
+    const { config } = useSiteStore()
+
+    return {
+      config,
+    }
   },
 
   computed: {
@@ -42,7 +51,7 @@ export default defineNuxtComponent({
   methods: {
     url(format: 'geojson' | 'csv'): string {
       return getPoiByCategoryIdUrl(
-        useSiteStore().config!,
+        this.config!,
         this.categoryId,
         {
           geometry_as: 'point',


### PR DESCRIPTION
I can't reproduce this bug neither on `yarn dev` or `yarn build && yarn start` so it doesn't seems to be a build time error ...

Anyway I move the `siteStore()` instance call on a `setup` function, which is more conventional instead of calling it twice in method, maybe it will fix it on Dev server ?
