### PR TITLE
Change cypress baseUrl

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "exclude": ["bin"]
 }


### PR DESCRIPTION
Had to exclude `bin` folder from typecheck.
Because we are now typechecking during build time.