### PR TITLE
Execute init poi layer on feature watcher

### DIFF
--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -48,6 +48,13 @@ export const menuStore = defineStore('menu', {
   }),
 
   getters: {
+    featuresColor: (state: State) => {
+      const colors = Object.values(state.features)
+        .flat()
+        .filter(feature => feature.properties.display)
+        .map(feature => feature.properties.display!.color_fill)
+      return [...new Set(colors)]
+    },
     apiMenuCategory: (state: State): ApiMenuCategory[] | undefined => {
       return state.menuItems === undefined
         ? undefined


### PR DESCRIPTION
The fix looks ok for any user interactions (initial load, categories click etc ...) but we are loosing POI layer during Hot Module Reloading in dev mode because 'features' watcher isn't trigger in this scenario.
I will fix it later, after a refactor of MapFeatures and MapBase component first and later a reorganization of the map different methods.