### PR TITLE
Bus show referenced objects on the main map

### DIFF
--- a/components/Home/Embedded.vue
+++ b/components/Home/Embedded.vue
@@ -179,7 +179,7 @@ function toggleExploreAroundSelectedPoi() {
         <UIButton
           :label="t('ui.close')"
           icon="times"
-          @click="mapStore.setSelectedFeature(null)"
+          @click="mapStore.setSelectedFeature()"
         />
       </div>
       <PoiCardContent

--- a/components/Home/Home.vue
+++ b/components/Home/Home.vue
@@ -285,11 +285,11 @@ watch(isModeFavorites, async (isEnabled) => {
 // Methods
 //
 function goToSelectedFeature(feature?: ApiPoi) {
-  if (feature)
-    mapStore.setSelectedFeature(feature)
-
-  if (mapFeaturesRef.value)
+  if (mapFeaturesRef.value) {
+    if (feature)
+      mapFeaturesRef.value.updateSelectedFeature(feature)
     mapFeaturesRef.value.goToSelectedFeature()
+  }
 }
 
 async function fetchAddress(hash: string) {
@@ -358,7 +358,7 @@ function onBottomMenuButtonClick() {
 
 function onQuitExplorerFavoriteMode() {
   mode.value = Mode.BROWSER
-  mapStore.setSelectedFeature(null)
+  mapStore.setSelectedFeature()
 }
 
 function toggleFavoriteMode() {
@@ -405,12 +405,9 @@ function routerPushUrl(hashUpdate: { [key: string]: string | null } = {}) {
 }
 
 function toggleExploreAroundSelectedPoi(feature?: ApiPoi) {
-  if (feature)
-    mapStore.setSelectedFeature(feature)
-
   if (!isModeExplorer.value) {
     mode.value = Mode.EXPLORER
-    goToSelectedFeature()
+    goToSelectedFeature(feature)
 
     if (device.value.smallScreen)
       isPoiCardShown.value = false
@@ -434,9 +431,7 @@ function toggleFavorite(feature: ApiPoi) {
 }
 
 function searchSelectFeature(feature: ApiPoi) {
-  mapStore.setSelectedFeature(feature)
-  goToSelectedFeature()
-
+  goToSelectedFeature(feature)
   teritorioCluster.value?.setSelectedFeature(feature as unknown as MapGeoJSONFeature)
 }
 
@@ -451,7 +446,9 @@ function scrollTop() {
 }
 
 function handlePoiCardClose() {
-  mapStore.setSelectedFeature(null)
+  if (mapFeaturesRef.value) {
+    mapFeaturesRef.value.updateSelectedFeature()
+  }
 }
 </script>
 

--- a/components/Map/MapBase.vue
+++ b/components/Map/MapBase.vue
@@ -63,7 +63,6 @@ const emit = defineEmits<{
   (e: 'mapTouchMove', event: MapTouchEvent & object): void
   (e: 'mapZoomEnd', event: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined> & object): void
   (e: 'mapStyleLoad', style: StyleSpecification): void
-  (e: 'featureClick', feature: ApiPoi): void
 }>()
 
 const POI_SOURCE = 'poi'

--- a/lib/apiPoiDeps.ts
+++ b/lib/apiPoiDeps.ts
@@ -22,7 +22,6 @@ export interface ApiRouteWaypointProperties {
   'id': ApiPoiId
   'name'?: MultilingualString
   'description'?: MultilingualString
-
   'route:point:type': ApiRouteWaypointType
 }
 

--- a/stores/map.ts
+++ b/stores/map.ts
@@ -32,7 +32,7 @@ export const mapStore = defineStore('map', {
   },
 
   actions: {
-    setSelectedFeature(feature: ApiPoi | null) {
+    setSelectedFeature(feature?: ApiPoi) {
       if (!feature) {
         this.selectedFeature = null
         this.teritorioCluster?.resetSelectedFeature()

--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -251,6 +251,14 @@ export const menuStore = defineStore('menu', {
       }
     },
 
+    filterByDeps(categoryIds: number[], deps: ApiPoi[]) {
+      const filteredFeatures: { [key: number]: ApiPoi[] } = {}
+      categoryIds.forEach((id) => {
+        filteredFeatures[id] = deps
+      })
+      this.features = filteredFeatures
+    },
+
     applyFilters({
       categoryId,
       filterValues,

--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -192,8 +192,7 @@ export const menuStore = defineStore('menu', {
                   return getPoiByCategoryId(vidoConfig, categoryId, options)
                 }
                 catch (e) {
-                  // eslint-disable-next-line no-console
-                  console.log('Vido error:', e)
+                  console.error('Vido error:', e)
                   return undefined
                 }
               })
@@ -251,10 +250,12 @@ export const menuStore = defineStore('menu', {
       }
     },
 
-    filterByDeps(categoryIds: number[], deps: ApiPoi[]) {
+    filterByDeps(categoryIds: number[], deps: ApiPoi[], selectedFeature: ApiPoi | null) {
       const filteredFeatures: { [key: number]: ApiPoi[] } = {}
       categoryIds.forEach((id) => {
         filteredFeatures[id] = deps
+        if (selectedFeature?.properties.metadata.category_ids?.includes(id))
+          filteredFeatures[id].push(selectedFeature)
       })
       this.features = filteredFeatures
     },


### PR DESCRIPTION
# Regression (fix in another PR)
- onQuitExplorerFavoriteMode we are missing POIs on map because of race condition between updateSelectedFeature() and mode watcher (which triggers a router push). We should update the route THEN fetch features accordingly (taking in account selected categories and selected feature) [#496](https://github.com/teritorio/vido/issues/496)