### PR TITLE
fix(sitemap): preserve trailing slash in sitemap urls

### DIFF
--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -56,7 +56,7 @@ export default defineEventHandler(async (event) => {
         xsl: '/sitemap-style.xsl',
         defaults: {},
         enabled: true,
-        trailingSlash: false,
+        trailingSlash: true,
         siteUrl: `https://${hostname}`,
         autoLastmod: false,
         inferStaticPagesAsRoutes: false,


### PR DESCRIPTION
## Summary
Fix broken sitemap URLs for category pages that were returning 404.

## Changes
- Set `trailingSlash: true` in sitemap builder options to prevent the library from stripping trailing slashes on category URLs
- Without the trailing slash, `/{categoryId}` was interpreted as a POI ID instead of a category route

## Issue
Closes #732

## Test Plan
- [ ] Visit `/sitemap.xml` and verify category URLs have trailing slashes (e.g. `/123/`)
- [ ] Click category links from the sitemap and verify they don't 404