### PR TITLE
feat(seo): add category name to title meta tag

### DIFF
--- a/pages/category.vue
+++ b/pages/category.vue
@@ -2,6 +2,7 @@
 import { storeToRefs } from 'pinia'
 import { menuStore as useMenuStore } from '~/stores/menu'
 import { useSiteStore } from '~/stores/site'
+import { type SiteInfosTheme, headerFromSettings } from '~/lib/apiSettings'
 import Header from '~/components/Layout/Header.vue'
 import Footer from '~/components/Layout/Footer.vue'
 import PoisTable from '~/components/PoisList/PoisTable.vue'
@@ -11,9 +12,9 @@ import CategorySelector from '~/components/PoisList/CategorySelector.vue'
 // Composables
 //
 const siteStore = useSiteStore()
-const { settings } = siteStore
+const { settings, theme } = storeToRefs(siteStore)
 const menuStore = useMenuStore()
-const { menuItems } = storeToRefs(menuStore)
+const { menuItems, getCurrentCategory } = storeToRefs(menuStore)
 const { $trackingInit } = useNuxtApp()
 const route = useRoute()
 
@@ -45,6 +46,23 @@ const isEmbedded = computed(() => {
 const isFiltersEqualToCategoryId = computed(() => {
   return filters.value?.length === 1 && filters.value[0] === categoryId.value
 })
+
+//
+// Head
+//
+const categoryName = computed(() => {
+  if (!categoryId.value)
+    return undefined
+  return getCurrentCategory.value(categoryId.value)?.category.name.fr
+})
+
+if (settings.value && theme.value) {
+  useHead(() => headerFromSettings(
+    theme.value as SiteInfosTheme,
+    settings.value!.icon_font_css_url,
+    { title: categoryName.value },
+  ))
+}
 
 //
 // Hooks

--- a/pages/embedded.vue
+++ b/pages/embedded.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import type { GeoJSONFeature } from 'maplibre-gl'
 import Embedded from '~/components/Home/Embedded.vue'
 import type { ApiPoi } from '~/types/api/poi'
+import { type SiteInfosTheme, headerFromSettings } from '~/lib/apiSettings'
 import { useSiteStore } from '~/stores/site'
 import { mapStore as useMapStore } from '~/stores/map'
 import { menuStore as useMenuStore } from '~/stores/menu'
@@ -13,7 +14,7 @@ import type { ApiPoiDepsCollection, ApiPoiUnion } from '~/types/api/poi-deps'
 import type { PoiUnion } from '~/types/local/poi-deps'
 
 const siteStore = useSiteStore()
-const { settings } = storeToRefs(siteStore)
+const { settings, theme } = storeToRefs(siteStore)
 const apiEndpoint = useState('api-endpoint')
 
 const route = useRoute()
@@ -22,7 +23,7 @@ const { $trackingInit } = useNuxtApp()
 const menuStore = useMenuStore()
 const poiDepsCompo = usePoiDeps()
 const { teritorioCluster } = storeToRefs(mapStore)
-const { selectedCategoryIds, apiMenuCategory } = storeToRefs(menuStore)
+const { selectedCategoryIds, apiMenuCategory, selectedCategories } = storeToRefs(menuStore)
 
 const mainPoi = ref<ApiPoi>()
 const boundaryGeojson = ref<Polygon | MultiPolygon>()
@@ -88,6 +89,18 @@ if (!categoryIds.value.length) {
 }
 
 menuStore.setSelectedCategoryIds(categoryIds.value)
+
+if (settings.value && theme.value) {
+  useHead(() => headerFromSettings(
+    theme.value as SiteInfosTheme,
+    settings.value!.icon_font_css_url,
+    {
+      title: selectedCategories.value?.length === 1
+        ? selectedCategories.value[0].category.name.fr
+        : undefined,
+    },
+  ))
+}
 
 const { data, error, status } = await useAsyncData('features', async () => {
   await menuStore.fetchFeatures({

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,6 +6,7 @@ import type { ApiPoi } from '~/types/api/poi'
 import type { ApiPoiDepsCollection, ApiPoiUnion } from '~/types/api/poi-deps'
 import { usePoiDeps } from '~/composables/usePoiDeps'
 import Home from '~/components/Home/Home.vue'
+import { type SiteInfosTheme, headerFromSettings } from '~/lib/apiSettings'
 import { useSiteStore } from '~/stores/site'
 import { menuStore as useMenuStore } from '~/stores/menu'
 import { mapStore as useMapStore } from '~/stores/map'
@@ -13,7 +14,7 @@ import { regexForCategoryIds } from '~/composables/useIdsResolver'
 import type { Poi } from '~/types/local/poi'
 import type { PoiUnion } from '~/types/local/poi-deps'
 
-const { settings } = storeToRefs(useSiteStore())
+const { settings, theme } = storeToRefs(useSiteStore())
 const apiEndpoint = useState('api-endpoint')
 
 const route = useRoute()
@@ -22,7 +23,7 @@ const { $trackingInit } = useNuxtApp()
 const menuStore = useMenuStore()
 const poiDepsCompo = usePoiDeps()
 const { teritorioCluster } = storeToRefs(mapStore)
-const { apiMenuCategory, selectedCategoryIds } = storeToRefs(menuStore)
+const { apiMenuCategory, selectedCategoryIds, selectedCategories } = storeToRefs(menuStore)
 
 const mainPoi = ref<ApiPoi>()
 const boundaryGeojson = ref<Polygon | MultiPolygon>()
@@ -85,6 +86,18 @@ if (!categoryIds.value.length) {
 }
 
 menuStore.setSelectedCategoryIds(categoryIds.value)
+
+if (settings.value && theme.value) {
+  useHead(() => headerFromSettings(
+    theme.value as SiteInfosTheme,
+    settings.value!.icon_font_css_url,
+    {
+      title: selectedCategories.value?.length === 1
+        ? selectedCategories.value[0].category.name.fr
+        : undefined,
+    },
+  ))
+}
 
 const { data, error, status } = await useAsyncData('features', async () => {
   await menuStore.fetchFeatures({


### PR DESCRIPTION
## Summary
When a category is identified from the URL, include its name in the page's `<title>` meta tag for better SEO.

## Changes
- **`pages/index.vue`**: when exactly 1 category is selected, title becomes `"Site Title - Category Name"`
- **`pages/category.vue`**: for `/category/<id>` and `/category/embedded/<id>`, title includes the category name
- **`pages/embedded.vue`**: for `/embedded/<categoryId>` with a single category, title includes the category name
- When 0 or 2+ categories are selected, the default title is used

## Issue
Closes #734

## Test Plan
- [ ] Navigate to `/<categoryId>/` and verify the browser tab shows `Site Title - Category Name`
- [ ] Navigate to `/category/<categoryId>` and verify the category name appears in the title
- [ ] Navigate to `/category/embedded/<categoryId>` and verify the category name appears in the title
- [ ] Navigate to `/embedded/<categoryId>` and verify the category name appears in the title
- [ ] Select multiple categories and verify the default title is shown
- [ ] Select no categories and verify the default title is shown