### PR TITLE
Link Sentry production project to version tags in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,5 +115,5 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ github.ref == 'refs/heads/main' && secrets.SENTRY_PROJECT_PROD || secrets.SENTRY_PROJECT_DEV }}
+          SENTRY_PROJECT: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && secrets.SENTRY_PROJECT_PROD || secrets.SENTRY_PROJECT_DEV }}
           SENTRY_URL: ${{ secrets.SENTRY_URL }}


### PR DESCRIPTION
## Summary

- Use `SENTRY_PROJECT_PROD` for version tag builds (`refs/tags/v*`) in addition to `main`, so Sentry releases from tags are tracked in the production project

Closes #757

## Test plan

- [ ] Verify that a push to a `v*` tag triggers Docker build with `SENTRY_PROJECT_PROD`
- [ ] Verify that `develop` branch still uses `SENTRY_PROJECT_DEV`
- [ ] Verify that `main` branch still uses `SENTRY_PROJECT_PROD`