### PR TITLE
fix: add missing optional chaining in description locale and menu parent_id

### DIFF
--- a/components/Home/Menu.vue
+++ b/components/Home/Menu.vue
@@ -62,7 +62,7 @@ const categoriesActivesCountByParent = computed((): Record<ApiMenuCategory['id']
     let parentId = menuItems?.value?.[categoryId]?.parent_id
     while (parentId) {
       counts[parentId] = (counts[parentId] || 0) + 1
-      parentId = menuItems?.value?.[parentId].parent_id
+      parentId = menuItems?.value?.[parentId]?.parent_id
     }
   })
   return counts

--- a/pages/poi/[id]/details.vue
+++ b/pages/poi/[id]/details.vue
@@ -73,7 +73,7 @@ if (settings.value && theme.value) {
       {
         title: featureSeoTitle.value,
         description: {
-          fr: poi.value?.properties.description?.['fr-FR'].value,
+          fr: poi.value?.properties.description?.['fr-FR']?.value,
         },
       },
     ),


### PR DESCRIPTION
## Summary
- Add missing `?.` on `description?.['fr-FR']?.value` in `pages/poi/[id]/details.vue`
- Add missing `?.` on `menuItems?.value?.[parentId]?.parent_id` in `components/Home/Menu.vue`

## Sentry Issues
- [VIDO-119](https://sentry.teritorio.xyz/organizations/teritorio/issues/2258/) — `Cannot read properties of undefined (reading 'value')`
- [VIDO-10K](https://sentry.teritorio.xyz/organizations/teritorio/issues/2176/) — `can't access property "parent_id", B[b] is undefined`

Closes #759
Closes #760

## Test plan
- [ ] Open a POI detail page where the description has no `fr-FR` locale — should not crash
- [ ] Navigate categories where a menu item references a non-existent parent — should not crash