### PR TITLE
fix: encode URL before redirect in image proxy

### DIFF
--- a/server/routes/image-proxy.get.ts
+++ b/server/routes/image-proxy.get.ts
@@ -16,15 +16,17 @@ export default defineEventHandler(async (event) => {
   // @ts-expect-error: can't declare the interface
   const allowedDomains: string[] = [...defaultDomains, ...(globalThis.allowedDomains[project] || [])]
 
+  const encodedUrl = encodeURI(url)
+
   if (!allowedDomains.includes(domain)) {
-    return sendRedirect(event, url)
+    return sendRedirect(event, encodedUrl)
   }
 
   try {
     const response = await fetch(url)
 
     if (!response.ok) {
-      return sendRedirect(event, url)
+      return sendRedirect(event, encodedUrl)
     }
 
     const arrayBuffer = await response.arrayBuffer()
@@ -45,6 +47,6 @@ export default defineEventHandler(async (event) => {
     return processedBuffer
   }
   catch {
-    return sendRedirect(event, url)
+    return sendRedirect(event, encodedUrl)
   }
 })


### PR DESCRIPTION
## Summary
Encode URL with `encodeURI()` before passing it to `sendRedirect()` in the image proxy handler, preventing `Invalid character in header content ["location"]` errors when URLs contain non-ASCII characters.

## Sentry Issue
[VIDO-118](https://sentry.teritorio.xyz/organizations/teritorio/issues/2257/) — 35 events

Closes #761

## Test plan
- [ ] Request image proxy with a URL containing non-ASCII characters (e.g. accented city names) — should redirect without error
- [ ] Request image proxy with a standard ASCII URL — should work as before