### PR TITLE
fix: fallback to main POI category for deps without category_ids

### DIFF
--- a/composables/usePoiDeps.ts
+++ b/composables/usePoiDeps.ts
@@ -1,3 +1,4 @@
+import { captureMessage } from '@sentry/nuxt'
 import { ApiRouteWaypointTypeObject } from '~/types/api/poi-deps'
 import type { ApiPoiDeps, ApiPoiDepsCollection, ApiPoiUnion } from '~/types/api/poi-deps'
 import { type PoiUnion, iconMap } from '~/types/local/poi-deps'
@@ -111,12 +112,22 @@ export function usePoiDeps() {
       : collection.features
 
     return sortedFeatures.map((feature) => {
-      const catId = isWaypoint(feature) ? mainPoi.properties.metadata.category_ids?.[0] : feature.properties.metadata.category_ids?.[0]
+      let catId = feature.properties.metadata.category_ids?.[0]
+
+      if (!catId) {
+        catId = mainPoi.properties.metadata.category_ids?.[0]
+        captureMessage(`Feature ${feature.properties.metadata.id} has no category_ids, falling back to main POI category`, 'warning')
+      }
 
       if (!catId)
         throw createError(`Category ID not found for feature ${feature.properties.metadata.id}.`)
 
-      const category = menuStore.getCurrentCategory(catId)
+      let category = menuStore.getCurrentCategory(catId)
+
+      if (!category) {
+        captureMessage(`Category ${catId} not found in menu for feature ${feature.properties.metadata.id}`, 'warning')
+        category = menuStore.getCurrentCategory(mainPoi.properties.metadata.category_ids?.[0] as number)
+      }
 
       if (!category)
         throw createError(`Category ${catId} not found.`)


### PR DESCRIPTION
## Summary
When a dependency feature has no `category_ids` or references a category not in the menu, fall back to the main POI's category instead of crashing. A warning is sent to Sentry to keep tracking API inconsistencies.

**Before:** Missing or invalid `category_ids` caused a fatal error during SSR, returning a 500 to the user.

**After:**
- Feature with no `category_ids` → falls back to main POI's category + Sentry warning
- Feature with `category_id` not in menu → falls back to main POI's category + Sentry warning
- Both fallbacks fail → still throws (shouldn't happen in practice)

## Root cause
The API returns dependency features (via `deps.geojson`) that can have:
- Empty `category_ids` (expected for waypoints, but also happens for non-waypoint deps like feature `16573` on hossegor)
- `category_ids` referencing categories not present in `menu.json` (e.g. categories `6752-6761` on aube-champagne)

## Sentry
[VIDO-11C](https://sentry.teritorio.xyz/organizations/teritorio/issues/2261/) — 59 events

New Sentry warnings will appear as:
- `"Feature X has no category_ids, falling back to main POI category"`
- `"Category X not found in menu for feature Y"`

Closes #762

## Test plan
- [ ] Open http://city-hossegor.localtest.me:3001/21918/17052 — renders without crash
- [ ] Verify waypoints on routes still display correctly
- [ ] Verify Sentry receives warning messages for features with missing categories
- [ ] Check carte.aube-champagne.com POI detail pages no longer crash