### PR TITLE
fix: guard against undefined poiId in feature lookup

### DIFF
--- a/pages/embedded.vue
+++ b/pages/embedded.vue
@@ -163,7 +163,7 @@ function getMainPoi(features: ApiPoiUnion[]): ApiPoi {
 function transformApiPoiDepsCollection(data?: ApiPoiDepsCollection): PoiUnion[] | undefined {
   poiDepsCompo.resetWaypointIndex()
 
-  if (!data)
+  if (!data || !poiId.value)
     return undefined
 
   mainPoi.value = getMainPoi(data.features)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -160,7 +160,7 @@ function getMainPoi(features: ApiPoiUnion[]): ApiPoi {
 function transformApiPoiDepsCollection(data?: ApiPoiDepsCollection): PoiUnion[] | undefined {
   poiDepsCompo.resetWaypointIndex()
 
-  if (!data)
+  if (!data || !poiId.value)
     return undefined
 
   mainPoi.value = getMainPoi(data.features)


### PR DESCRIPTION
## Summary
Add a guard in `transformApiPoiDepsCollection` to return early when `poiId.value` is undefined, preventing a `Feature with ID: undefined not found` crash.

Applied in both `pages/index.vue` and `pages/embedded.vue`.

## Root cause
`poiId.value` can become `undefined` between the initial fetch guard and when the `transform` callback runs (race condition during navigation). `Number(undefined)` returns `NaN` which never matches any feature ID, causing the error.

## Sentry Issue
[VIDO-YQ](https://sentry.teritorio.xyz/organizations/teritorio/issues/1957/) — 2 events, 2 users

Closes #763

## Test plan
- [ ] Navigate between category and POI views rapidly — should not crash
- [ ] Direct access to a POI detail URL still works normally