### PR TITLE
fix: guard localStorage access in favorite store against SecurityError

### DIFF
--- a/stores/favorite.ts
+++ b/stores/favorite.ts
@@ -22,27 +22,37 @@ export const favoriteStore = defineStore('favorite', () => {
   })
 
   function init() {
-    const poiFavorites = localStorage.getItem(LOCAL_STORAGE.favorites)
-    const addressFavorites = localStorage.getItem(LOCAL_STORAGE.favoritesAddr)
+    try {
+      const poiFavorites = localStorage.getItem(LOCAL_STORAGE.favorites)
+      const addressFavorites = localStorage.getItem(LOCAL_STORAGE.favoritesAddr)
 
-    if (poiFavorites) {
-      const favorites = JSON.parse(poiFavorites).favorites
-      favoritesIds.value = favorites
-      saveToLocalStorage(LOCAL_STORAGE.favorites, favorites)
+      if (poiFavorites) {
+        const favorites = JSON.parse(poiFavorites).favorites
+        favoritesIds.value = favorites
+        saveToLocalStorage(LOCAL_STORAGE.favorites, favorites)
+      }
+
+      if (addressFavorites) {
+        const entries: [string, string][] = JSON.parse(addressFavorites).favorites
+        favoriteAddressesObj.value = Object.fromEntries(entries)
+        saveToLocalStorage(LOCAL_STORAGE.favoritesAddr, entries)
+      }
     }
-
-    if (addressFavorites) {
-      const entries: [string, string][] = JSON.parse(addressFavorites).favorites
-      favoriteAddressesObj.value = Object.fromEntries(entries)
-      saveToLocalStorage(LOCAL_STORAGE.favoritesAddr, entries)
+    catch {
+      // localStorage unavailable (iframe restrictions, disabled cookies, etc.)
     }
   }
 
   function saveToLocalStorage(key: string, favorites?: number[] | [string, string][]) {
-    if (!favorites)
-      localStorage.removeItem(key)
-    else
-      localStorage.setItem(key, JSON.stringify({ favorites, version: 1 }))
+    try {
+      if (!favorites)
+        localStorage.removeItem(key)
+      else
+        localStorage.setItem(key, JSON.stringify({ favorites, version: 1 }))
+    }
+    catch {
+      // localStorage unavailable (iframe restrictions, disabled cookies, etc.)
+    }
   }
 
   function toggleFavoriteAddr(poi: Poi) {


### PR DESCRIPTION
## Summary
- Wrap all `localStorage` calls in `stores/favorite.ts` with try/catch
- Handles `SecurityError` thrown when storage is denied (iframe embeds, disabled cookies, strict privacy settings)
- Favorites gracefully degrade to in-memory only for the session

Closes #769

## Test plan
- [ ] Open a vido instance in an iframe with `sandbox` attribute (no `allow-same-origin`) and verify no crash
- [ ] Verify favorites still work normally in standard browsing
- [ ] Verify favorites work in-memory when localStorage is blocked (added favorites disappear on reload but no error)