### PR TITLE
fix: guard RoutesField compact mode against missing duration/difficulty

### DIFF
--- a/components/Fields/RoutesField.story.vue
+++ b/components/Fields/RoutesField.story.vue
@@ -32,20 +32,17 @@ const props = {
     properties: {
       'fr-FR': {
         hiking: {
-          difficulty: 'easy' as const,
-          duration: 0,
           length: 0,
         },
       },
     } as ApiPoiPropertiesRoute,
   },
-  MissingDifficulty: {
+  MissingDuration: {
     ...defaultProps,
     properties: {
       'fr-FR': {
         hiking: {
           difficulty: 'easy' as const,
-          duration: 285,
           length: 10.2,
         },
       },

--- a/components/Fields/RoutesField.vue
+++ b/components/Fields/RoutesField.vue
@@ -27,7 +27,7 @@ const routes = computed((): Record<string, RouteMetadata> => {
   return Object.fromEntries(entries.filter(([key, _value]) => !['gpx_trace', 'pdf'].includes(key))) as Record<string, RouteMetadata>
 })
 
-function formatDuration(duration: number): string | undefined {
+function formatDuration(duration?: number): string | undefined {
   if (!duration)
     return undefined
 
@@ -52,7 +52,10 @@ function formatDuration(duration: number): string | undefined {
   return `${formattedHours} ${formattedMinutes}`.trim()
 }
 
-function formatLength(length: number): string | undefined {
+function formatLength(length?: number): string | undefined {
+  if (!length)
+    return undefined
+
   return new Intl.NumberFormat(locale.value, { style: 'unit', unit: 'kilometer' }).format(length)
 }
 </script>
@@ -62,8 +65,16 @@ function formatLength(length: number): string | undefined {
     <slot />
     <div v-if="isCompact">
       <p v-for="(route, activity) in routes" :key="activity">
-        {{ pv('route', `${activity}`, context) }} : {{ formatDuration(route.duration) }}, {{ pv(`route:${activity}:difficulty`, route.difficulty, context) }}.
-        <br>
+        {{ pv('route', `${activity}`, context) }}
+        <template v-if="formatDuration(route.duration)">
+          : {{ formatDuration(route.duration) }}
+        </template>
+        <template v-if="route.difficulty">
+          {{ formatDuration(route.duration) ? ', ' : ': ' }}{{ pv(`route:${activity}:difficulty`, route.difficulty, context) }}
+        </template>
+        <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
+        <template v-if="formatDuration(route.duration) || route.difficulty">.</template>
+        <br v-if="route.length">
         <span v-if="route.length">
           {{ formatLength(route.length) }}
         </span>

--- a/types/api/poi.ts
+++ b/types/api/poi.ts
@@ -51,9 +51,9 @@ export interface ApiPoiPropertiesRouteLanguage {
 export type ApiPoiPropertiesRoute = Partial<Record<LanguageCode, ApiPoiPropertiesRouteLanguage>>
 
 export interface RouteMetadata {
-  difficulty: 'easy' | 'normal' | 'hard'
-  duration: number
-  length: number
+  difficulty?: 'easy' | 'normal' | 'hard'
+  duration?: number
+  length?: number
 }
 
 export interface ApiPoiPropertiesMetadata {


### PR DESCRIPTION
## Summary

- Guard compact mode template in `RoutesField.vue` with `v-if` to avoid rendering stray `: , .` punctuation when `duration` or `difficulty` is missing
- Make `RouteMetadata` fields (`difficulty`, `duration`, `length`) optional in `types/api/poi.ts` to match the actual API response
- Update story variants with truly missing fields and a `MissingDuration` case

Closes #774

## Test plan

- [ ] Verify POI 193607 (missing duration/difficulty) no longer shows stray punctuation in card mode
- [ ] Verify POIs with all fields still render correctly (activity : duration, difficulty.)
- [ ] Verify detail mode is unaffected
- [ ] Check story variants in Histoire: `MissingFields` and `MissingDuration`