### PR TITLE
fix: scope inline-flex to list items only to fix Firefox marker

### DIFF
--- a/components/Fields/Field.vue
+++ b/components/Fields/Field.vue
@@ -209,4 +209,9 @@ const translatedValue = computed(() => {
 .tw-prose {
   max-width: none;
 }
+
+// Fix Firefox mobile ::marker misalignment when <li> contains a flex <a>
+li :deep(a) {
+  display: inline-flex;
+}
 </style>

--- a/components/Fields/FieldLink.vue
+++ b/components/Fields/FieldLink.vue
@@ -40,7 +40,7 @@ const iconDefault = computed((): string => {
       color: ['label_popup', 'label_list'].includes(context) ? colorText : 'unset',
     }"
     :class="{
-      'tw-inline-flex tw-flex-row tw-items-center tw-gap-x-2.5 tw-underline tw-underline-offset-4': !['label_popup', 'label_list'].includes(context),
+      'tw-flex tw-flex-row tw-items-center tw-gap-x-2.5 tw-underline tw-underline-offset-4': !['label_popup', 'label_list'].includes(context),
       'tw-inline-flex tw-items-center tw-justify-center tw-gap-1 pa-2 rounded-lg': ['label_popup', 'label_list'].includes(context),
     }"
   >

--- a/components/UI/ExternalLink.vue
+++ b/components/UI/ExternalLink.vue
@@ -28,7 +28,7 @@ const iconDefault = computed((): string => {
     :target="target"
     :rel="rel"
     :title="title"
-    class="tw-inline-flex tw-flex-row tw-items-center tw-gap-x-2.5 tw-underline tw-underline-offset-4"
+    class="tw-flex tw-flex-row tw-items-center tw-gap-x-2.5 tw-underline tw-underline-offset-4"
   >
     <FontAwesomeIcon :icon="iconDefault" color="inherit" size="sm" />
     <slot />


### PR DESCRIPTION
Revert global inline-flex on ExternalLink and FieldLink which broke ContribFieldGroup layout. Instead, apply inline-flex via scoped CSS in Field.vue targeting only <a> inside <li> elements.