### PR TITLE
fix: prevent module-level defaultOptions mutation in apiPois

### DIFF
--- a/lib/apiPois.ts
+++ b/lib/apiPois.ts
@@ -70,7 +70,7 @@ export function getPoiByCategoryIdUrl(
 ): string {
   const apiEndpoint = useState('api-endpoint')
 
-  options = Object.assign(defaultOptions, { geometry_as: 'point' }, options)
+  options = Object.assign({}, defaultOptions, { geometry_as: 'point' }, options)
   return (
     `${apiEndpoint.value}/pois/category/${categoryId}.${options.format}?${
     new URLSearchParams(stringifyOptions(options))}`
@@ -81,7 +81,7 @@ export async function getPoiByCategoryId(
   categoryId: number | string,
   options: ApiPoisOptions = {},
 ): Promise<ApiPoiCollection> {
-  options = Object.assign(defaultOptions, { geometry_as: 'point' }, options)
+  options = Object.assign({}, defaultOptions, { geometry_as: 'point' }, options)
 
   return await fetch(getPoiByCategoryIdUrl(categoryId, options)).then(
     async (data) => {


### PR DESCRIPTION
## Summary
- Fixes `Object.assign(defaultOptions, ...)` calls in `lib/apiPois.ts` that mutated the module-level `defaultOptions` object, causing subsequent calls to use polluted option values.
- Changed to `Object.assign({}, defaultOptions, ...)` to create a fresh object each time, preserving the original defaults.

Closes #784
Related to #780

## Test plan
- [ ] Verify that repeated calls to `getPoiByCategoryIdUrl` and `getPoiByCategoryId` with different options do not leak state between calls
- [ ] Confirm no regressions in POI loading behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)