### PR TITLE
fix: reset allFeatures and features on menu config change

### DIFF
--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -248,6 +248,8 @@ export const menuStore = defineStore('menu', () => {
       const localFilters: Record<number, FilterValues> = {}
       const localGlobalFilters: Record<number, FilterValues> = {}
 
+      allFeatures.value = {}
+      features.value = {}
       menuItems.value = undefined // Hack, release from store before edit and reappend
       items
         .map((menuItem) => {


### PR DESCRIPTION
## Summary

- Reset `allFeatures` and `features` reactive objects in `fetchConfig()` before rebuilding the menu, preventing stale POI data from persisting across config changes.
- Fixes #782 (part of #780)

## Test plan

- [ ] Verify that switching menu configurations clears previous POI features from the map
- [ ] Confirm no regression in normal POI loading after menu fetch