### PR TITLE
refactor: pass apiEndpoint as parameter to lib/apiPois functions

### DIFF
--- a/components/Home/Embedded.vue
+++ b/components/Home/Embedded.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   initialCategoryIds?: number[]
 }>()
 
+const apiEndpoint = useState<string>('api-endpoint')
 const mapStore = useMapStore()
 const { isModeExplorer, mode, selectedFeature, isDepsView } = storeToRefs(mapStore)
 const menuStore = useMenuStore()
@@ -89,6 +90,7 @@ watch(selectedFeature, (newFeature, oldFeature) => {
 
   if (!isDepsView.value) {
     menuStore.fetchFeatures({
+      apiEndpoint: apiEndpoint.value,
       categoryIds: selectedCategoryIds.value,
       clipingPolygonSlug: route.query.clipingPolygonSlug?.toString(),
     })
@@ -101,6 +103,7 @@ watch(selectedCategoryIds, (a, b) => {
 
     if (!isDepsView.value) {
       menuStore.fetchFeatures({
+        apiEndpoint: apiEndpoint.value,
         categoryIds: selectedCategoryIds.value,
         clipingPolygonSlug: route.query.clipingPolygonSlug?.toString(),
       })

--- a/components/Home/Home.vue
+++ b/components/Home/Home.vue
@@ -38,6 +38,7 @@ const props = defineProps<{
 }>()
 
 const { apiAddr } = useRuntimeConfig().public
+const apiEndpoint = useState<string>('api-endpoint')
 const mapStore = useMapStore()
 const { isModeFavorites, isModeExplorer, isModeExplorerOrFavorites, mode, selectedFeature, teritorioCluster, isDepsView } = storeToRefs(mapStore)
 const menuStore = useMenuStore()
@@ -200,6 +201,7 @@ watch(selectedFeature, (newFeature, oldFeature) => {
     }
     else if (!isDepsView.value) {
       menuStore.fetchFeatures({
+        apiEndpoint: apiEndpoint.value,
         categoryIds: selectedCategoryIds.value,
         clipingPolygonSlug: route.query.clipingPolygonSlug?.toString(),
       })
@@ -213,6 +215,7 @@ watch(selectedCategoryIds, (a, b) => {
 
     if (!isDepsView.value) {
       menuStore.fetchFeatures({
+        apiEndpoint: apiEndpoint.value,
         categoryIds: selectedCategoryIds.value,
         clipingPolygonSlug: route.query.clipingPolygonSlug?.toString(),
       })
@@ -277,7 +280,7 @@ async function fetchFavorites(): Promise<Poi[]> {
   if (route.query.clipingPolygonSlug)
     query.cliping_polygon_slug = route.query.clipingPolygonSlug.toString()
 
-  return await getPois(favoritesIds.value, query)
+  return await getPois(apiEndpoint.value, favoritesIds.value, query)
     .then(pois => pois.features.map((feature) => {
       const catId = feature.properties.metadata.category_ids?.[0]
 

--- a/components/PoisList/Actions.vue
+++ b/components/PoisList/Actions.vue
@@ -9,6 +9,8 @@ const props = defineProps<{
   colorLine: string
 }>()
 
+const apiEndpoint = useState<string>('api-endpoint')
+
 const urlMap = computed((): string => `/${props.categoryId}/`)
 
 const urlCsv = computed((): string => url('csv'))
@@ -26,7 +28,7 @@ function url(format: 'geojson' | 'csv'): string {
   if (route.query.clipingPolygonSlug)
     query.cliping_polygon_slug = route.query.clipingPolygonSlug.toString()
 
-  return getPoiByCategoryIdUrl(props.categoryId, query)
+  return getPoiByCategoryIdUrl(apiEndpoint.value, props.categoryId, query)
 }
 </script>
 

--- a/lib/apiPois.ts
+++ b/lib/apiPois.ts
@@ -20,13 +20,12 @@ export function stringifyOptions(options: ApiPoisOptions): string[][] {
 }
 
 export function getPoiById(
+  apiEndpoint: string,
   poiId: number | string,
   options: ApiPoisOptions = {},
 ): Promise<ApiPoi> {
-  const apiEndpoint = useState('api-endpoint')
-
   return fetch(
-    `${apiEndpoint.value}/poi/${poiId}.${options.format || defaultOptions.format}?${new URLSearchParams(stringifyOptions(options))}`,
+    `${apiEndpoint}/poi/${poiId}.${options.format || defaultOptions.format}?${new URLSearchParams(stringifyOptions(options))}`,
   )
     .then((data) => {
       if (data.ok) {
@@ -41,13 +40,12 @@ export function getPoiById(
 }
 
 export async function getPois(
+  apiEndpoint: string,
   poiIds?: (number | string)[],
   options: ApiPoisOptions = {},
 ): Promise<ApiPoiCollection> {
-  const apiEndpoint = useState('api-endpoint')
-
   return await fetch(
-    `${apiEndpoint.value}/pois.${options.format || defaultOptions.format}?${
+    `${apiEndpoint}/pois.${options.format || defaultOptions.format}?${
       new URLSearchParams([
         ...(poiIds ? [['ids', poiIds.join(',')]] : []),
         ...stringifyOptions(options),
@@ -65,25 +63,25 @@ export async function getPois(
 }
 
 export function getPoiByCategoryIdUrl(
+  apiEndpoint: string,
   categoryId: number | string,
   options: ApiPoisOptions = {},
 ): string {
-  const apiEndpoint = useState('api-endpoint')
-
-  options = Object.assign(defaultOptions, { geometry_as: 'point' }, options)
+  options = Object.assign({}, defaultOptions, { geometry_as: 'point' }, options)
   return (
-    `${apiEndpoint.value}/pois/category/${categoryId}.${options.format}?${
+    `${apiEndpoint}/pois/category/${categoryId}.${options.format}?${
     new URLSearchParams(stringifyOptions(options))}`
   )
 }
 
 export async function getPoiByCategoryId(
+  apiEndpoint: string,
   categoryId: number | string,
   options: ApiPoisOptions = {},
 ): Promise<ApiPoiCollection> {
-  options = Object.assign(defaultOptions, { geometry_as: 'point' }, options)
+  options = Object.assign({}, defaultOptions, { geometry_as: 'point' }, options)
 
-  return await fetch(getPoiByCategoryIdUrl(categoryId, options)).then(
+  return await fetch(getPoiByCategoryIdUrl(apiEndpoint, categoryId, options)).then(
     async (data) => {
       if (data.ok) {
         return await data.json() as unknown as ApiPoiCollection

--- a/pages/embedded.vue
+++ b/pages/embedded.vue
@@ -104,6 +104,7 @@ if (settings.value && theme.value) {
 
 const { data, error, status } = await useAsyncData('features', async () => {
   await menuStore.fetchFeatures({
+    apiEndpoint: apiEndpoint.value as string,
     categoryIds: categoryIds.value || [],
     clipingPolygonSlug: route.query.clipingPolygonSlug?.toString(),
   })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -101,6 +101,7 @@ if (settings.value && theme.value) {
 
 const { data, error, status } = await useAsyncData('features', async () => {
   await menuStore.fetchFeatures({
+    apiEndpoint: apiEndpoint.value as string,
     categoryIds: categoryIds.value || [],
     clipingPolygonSlug: route.query.clipingPolygonSlug?.toString(),
   })

--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -13,6 +13,7 @@ import type { PoiUnion } from '~/types/local/poi-deps'
 import type { FieldsList, FieldsListGroup, FieldsListItem } from '~/types/local/field'
 
 interface FetchFeaturesPayload {
+  apiEndpoint: string
   categoryIds: ApiMenuCategory['id'][]
   clipingPolygonSlug?: string
 }
@@ -305,7 +306,7 @@ export const menuStore = defineStore('menu', () => {
     }
   }
 
-  async function fetchFeatures({ categoryIds, clipingPolygonSlug }: FetchFeaturesPayload) {
+  async function fetchFeatures({ apiEndpoint, categoryIds, clipingPolygonSlug }: FetchFeaturesPayload) {
     isLoadingFeatures.value = true
 
     try {
@@ -323,7 +324,7 @@ export const menuStore = defineStore('menu', () => {
                 let options = {}
                 if (clipingPolygonSlug)
                   options = { cliping_polygon_slug: clipingPolygonSlug }
-                return getPoiByCategoryId(categoryId, options)
+                return getPoiByCategoryId(apiEndpoint, categoryId, options)
               }
               catch (e) {
                 console.error('Vido error:', e)

--- a/stores/search.ts
+++ b/stores/search.ts
@@ -12,6 +12,7 @@ import type { Poi } from '~/types/local/poi'
 export const useSearchStore = defineStore('search', () => {
   const { apiAddr, apiSearch } = useRuntimeConfig().public
   const { $tracking } = useNuxtApp()
+  const apiEndpoint = useState<string>('api-endpoint')
   const menuStore = useMenuStore()
   const { filters, apiMenuCategory } = storeToRefs(menuStore)
   const { center } = storeToRefs(useMapStore())
@@ -205,7 +206,7 @@ export const useSearchStore = defineStore('search', () => {
   }
 
   async function onPoiClick(searchResult: SearchResult) {
-    const poi = await getPoiById(searchResult.id)
+    const poi = await getPoiById(apiEndpoint.value, searchResult.id)
     const catId = poi.properties.metadata.category_ids?.[0]
 
     if (!catId)
@@ -248,7 +249,7 @@ export const useSearchStore = defineStore('search', () => {
     const searchValue = searchText.value.trim()
     if (searchValue.length === 2) {
       const cartocode = searchText.value
-      getPoiById(`cartocode:${cartocode}`)
+      getPoiById(apiEndpoint.value, `cartocode:${cartocode}`)
         .then((poi) => {
           if (currentSearchQueryId > searchResultId.value) {
             searchResultId.value = currentSearchQueryId


### PR DESCRIPTION
## Summary

- Add `apiEndpoint: string` as the first parameter to all `lib/apiPois.ts` functions (`getPoiById`, `getPois`, `getPoiByCategoryIdUrl`, `getPoiByCategoryId`), removing implicit `useState('api-endpoint')` calls from library code
- Add `apiEndpoint: string` to the `FetchFeaturesPayload` interface in the menu store, threading the endpoint through `fetchFeatures`
- Fix `Object.assign` mutation bug in `getPoiByCategoryIdUrl` and `getPoiByCategoryId` — previously mutated the shared `defaultOptions` object; now uses `Object.assign({}, defaultOptions, ...)` to create a fresh copy
- Update all call sites (pages, components, stores) to pass the endpoint explicitly

Closes #783
Part of #780

## Test plan

- [ ] Verify map loads POIs correctly on the main page (`/`)
- [ ] Verify embedded map loads POIs correctly (`/embedded/`)
- [ ] Verify category POI list download links (CSV/GeoJSON) work
- [ ] Verify search by POI ID and cartocode still works
- [ ] Verify favorites mode loads POIs correctly