### PR TITLE
feat: include POI deps in /pois/<ids>/map page

### DIFF
--- a/pages/pois/[ids]/map.vue
+++ b/pages/pois/[ids]/map.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { captureMessage } from '@sentry/nuxt'
 import { storeToRefs } from 'pinia'
 import MapPois from '~/components/Map/MapPois.vue'
 import type { ApiPoi, ApiPoiCollection } from '~/types/api/poi'
+import type { ApiPoiDepsCollection } from '~/types/api/poi-deps'
+import type { PoiUnion } from '~/types/local/poi-deps'
 import { useSiteStore } from '~/stores/site'
 import { regexForCategoryIds } from '~/composables/useIdsResolver'
-import type { Poi } from '~/types/local/poi'
 import { menuStore as useMenuStore } from '~/stores/menu'
 
 definePageMeta({
@@ -18,6 +20,7 @@ const { $trackingInit } = useNuxtApp()
 const route = useRoute()
 const apiEndpoint = useState('api-endpoint')
 const poiCompo = usePoi()
+const poiDepsCompo = usePoiDeps()
 const menuStore = useMenuStore()
 
 const poiIds = computed(() => {
@@ -37,18 +40,67 @@ const poiIdsAsNumbers = computed(() => poiIds.value.map(id => Number(id)))
 
 const clipingPolygonSlug = computed(() => route.query.clipingPolygonSlug?.toString())
 
-const { data, error } = await useFetch(
-  `${apiEndpoint.value}/pois.geojson`,
-  {
-    query: {
-      ids: poiIds.value.join(','),
-      geometry_as: 'point',
-      short_description: true,
-      cliping_polygon_slug: clipingPolygonSlug.value,
+const { data, error } = await useAsyncData('pois-map', async () => {
+  const poisCollection = await $fetch<ApiPoiCollection>(
+    `${apiEndpoint.value}/pois.geojson`,
+    {
+      query: {
+        ids: poiIds.value.join(','),
+        geometry_as: 'point',
+        short_description: true,
+        cliping_polygon_slug: clipingPolygonSlug.value,
+      },
     },
-    transform: (data: ApiPoiCollection) => transformApiPoiCollection(data),
+  )
+
+  const depsResults = await Promise.allSettled(
+    poiIdsAsNumbers.value.map(poiId =>
+      $fetch<ApiPoiDepsCollection>(
+        `${apiEndpoint.value}/poi/${poiId}/deps.geojson`,
+        {
+          query: {
+            geometry_as: 'point',
+            short_description: true,
+          },
+        },
+      ),
+    ),
+  )
+
+  return { poisCollection, depsResults }
+}, {
+  transform: ({ poisCollection, depsResults }) => {
+    const mainPoiIds = new Set(poiIdsAsNumbers.value)
+
+    const mainPois = poisCollection.features.map((feature: ApiPoi) => {
+      const catId = feature.properties.metadata.category_ids?.[0]
+
+      if (!catId)
+        throw createError(`Category ID not found for feature ${feature.properties.metadata.id}.`)
+
+      const category = menuStore.getCurrentCategory(catId)
+
+      if (!category)
+        throw createError(`Category ${catId} not found.`)
+
+      return poiCompo.formatPoi(feature, category)
+    })
+
+    const deps = depsResults.flatMap((result, index) => {
+      if (result.status === 'rejected') {
+        captureMessage(`Failed to fetch deps for POI ${poiIdsAsNumbers.value[index]}: ${result.reason}`, 'warning')
+        return []
+      }
+
+      if (!result.value.features?.length)
+        return []
+
+      return poiDepsCompo.formatPoiDepsCollection(result.value, poiIdsAsNumbers.value[index])
+    }).filter(dep => !mainPoiIds.has(dep.properties.metadata.id))
+
+    return [...mainPois, ...deps]
   },
-)
+})
 
 if (error.value) {
   throw createError(error.value)
@@ -61,27 +113,11 @@ if (!data.value?.length) {
   })
 }
 
-const features = computed(() => data.value ?? [])
+const features = computed<PoiUnion[]>(() => data.value ?? [])
 
 onBeforeMount(() => {
   $trackingInit()
 })
-
-function transformApiPoiCollection(data: ApiPoiCollection): Poi[] {
-  return data.features.map((feature: ApiPoi) => {
-    const catId = feature.properties.metadata.category_ids?.[0]
-
-    if (!catId)
-      throw createError(`Category ID not found for feature ${feature.properties.metadata.id}.`)
-
-    const category = menuStore.getCurrentCategory(catId)
-
-    if (!category)
-      throw createError(`Category ${catId} not found.`)
-
-    return poiCompo.formatPoi(feature, category)
-  })
-}
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

- Fetch POI dependencies (waypoints, parking, route start/end points) for each POI displayed on the `/pois/<ids>/map` page
- Uses `useAsyncData` with `$fetch` for SSR-compatible data fetching, consistent with other pages
- Deps are fetched in parallel via `Promise.allSettled` — individual failures are reported to Sentry and gracefully skipped
- Main POIs already in the primary fetch are excluded from deps to avoid duplicates

## Test plan

- [ ] Visit `/pois/<ids>/map` with POI IDs that have dependencies (routes with waypoints)
- [ ] Verify waypoints, parking, and route points appear on the map alongside main POIs
- [ ] Verify POIs without deps still render correctly
- [ ] Verify clicking on waypoint markers shows the correct card content

Closes #792