### PR TITLE
feat(seo): add structured data & SSR POI list (#737)

### DIFF
--- a/components/Home/Home.vue
+++ b/components/Home/Home.vue
@@ -440,7 +440,7 @@ onBeforeUnmount(() => {
 <template>
   <div class="tw-fixed tw-w-full tw-h-full tw-overflow-hidden tw-flex tw-flex-col">
     <h1 class="tw-absolute tw-text-white">
-      {{ siteName }}
+      {{ selectedCategories?.length === 1 ? `${selectedCategories[0].category.name.fr} — ${siteName}` : siteName }}
     </h1>
 
     <ClientOnly>

--- a/components/Home/Home.vue
+++ b/components/Home/Home.vue
@@ -440,7 +440,7 @@ onBeforeUnmount(() => {
 <template>
   <div class="tw-fixed tw-w-full tw-h-full tw-overflow-hidden tw-flex tw-flex-col">
     <h1 class="tw-absolute tw-text-white">
-      {{ selectedCategories?.length === 1 ? `${selectedCategories[0].category.name.fr} — ${siteName}` : siteName }}
+      {{ selectedCategories?.length === 1 && selectedCategories[0]?.category?.name?.fr ? `${selectedCategories[0].category.name.fr} — ${siteName}` : siteName }}
     </h1>
 
     <ClientOnly>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -144,9 +144,10 @@ if (settings.value && theme.value && isSingleCategory.value && singleCategory.va
               'name': `${categoryName} — ${themeTitle}`,
               'mainEntity': {
                 '@type': 'ItemList',
-                'itemListElement': namedCategoryFeatures.value.map((poi, index) => ({
+                'itemListElement': namedCategoryFeatures.value.slice(0, 100).map((poi, index) => ({
                   '@type': 'ListItem',
                   'position': index + 1,
+                  'name': poi.properties.name?.['fr-FR'] || poi.properties.name?.fr,
                   'url': `${origin}/poi/${poi.properties.metadata.id}/details`,
                 })),
               },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -22,7 +22,7 @@ const { $trackingInit } = useNuxtApp()
 const menuStore = useMenuStore()
 const poiDepsCompo = usePoiDeps()
 const { teritorioCluster } = storeToRefs(mapStore)
-const { apiMenuCategory, selectedCategoryIds, selectedCategories } = storeToRefs(menuStore)
+const { allFeatures, apiMenuCategory, selectedCategoryIds, selectedCategories } = storeToRefs(menuStore)
 
 const mainPoi = ref<ApiPoi>()
 const boundaryGeojson = ref<Polygon | MultiPolygon>()
@@ -86,6 +86,11 @@ if (!categoryIds.value.length) {
 
 menuStore.setSelectedCategoryIds(categoryIds.value)
 
+const isSingleCategory = computed(() => categoryIds.value.length === 1)
+const singleCategory = computed(() => isSingleCategory.value ? menuStore.getCurrentCategory(categoryIds.value[0]) : undefined)
+const categoryFeatures = computed(() => isSingleCategory.value ? allFeatures.value[categoryIds.value[0]] ?? [] : [])
+const namedCategoryFeatures = computed(() => categoryFeatures.value.filter(poi => poi.properties.name?.['fr-FR'] || poi.properties.name?.fr))
+
 if (settings.value && theme.value) {
   useHead(() => headerFromSettings(
     theme.value as SiteInfosTheme,
@@ -122,6 +127,35 @@ const { data, error, status } = await useAsyncData('features', async () => {
 
 if (error.value)
   throw createError(error.value)
+
+if (settings.value && theme.value && isSingleCategory.value && singleCategory.value) {
+  const origin = useRequestURL().origin
+  const categoryName = singleCategory.value.category.name.fr
+  const themeTitle = theme.value.title?.fr ?? ''
+
+  useHead(() => ({
+    script: namedCategoryFeatures.value.length
+      ? [
+          {
+            type: 'application/ld+json',
+            innerHTML: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'CollectionPage',
+              'name': `${categoryName} — ${themeTitle}`,
+              'mainEntity': {
+                '@type': 'ItemList',
+                'itemListElement': namedCategoryFeatures.value.map((poi, index) => ({
+                  '@type': 'ListItem',
+                  'position': index + 1,
+                  'url': `${origin}/poi/${poi.properties.metadata.id}/details`,
+                })),
+              },
+            }),
+          },
+        ]
+      : [],
+  }))
+}
 
 if (status.value === 'success' && data.value && mainPoi.value) {
   poiDepsCompo.processPoiDeps(data.value, mainPoi.value.properties.metadata.id, selectedCategoryIds.value)
@@ -176,11 +210,19 @@ onBeforeMount(() => {
       type="error"
       variant="elevated"
     />
-    <Home
-      v-else
-      :boundary-area="boundaryGeojson"
-      :initial-category-ids="categoryIds"
-    />
+    <template v-else>
+      <Home
+        :boundary-area="boundaryGeojson"
+        :initial-category-ids="categoryIds"
+      />
+      <ul v-if="isSingleCategory && namedCategoryFeatures.length" class="tw-sr-only">
+        <li v-for="poi in namedCategoryFeatures" :key="poi.properties.metadata.id">
+          <a :href="`/poi/${poi.properties.metadata.id}/details`">
+            {{ poi.properties.name?.['fr-FR'] || poi.properties.name?.fr }}
+          </a>
+        </li>
+      </ul>
+    </template>
   </VApp>
 </template>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -128,35 +128,37 @@ const { data, error, status } = await useAsyncData('features', async () => {
 if (error.value)
   throw createError(error.value)
 
-if (settings.value && theme.value && isSingleCategory.value && singleCategory.value) {
-  const origin = useRequestURL().origin
+const requestOrigin = useRequestURL().origin
+
+useHead(() => {
+  if (!settings.value || !theme.value || !isSingleCategory.value || !singleCategory.value || !namedCategoryFeatures.value.length)
+    return {}
+
   const categoryName = singleCategory.value.category.name.fr
   const themeTitle = theme.value.title?.fr ?? ''
 
-  useHead(() => ({
-    script: namedCategoryFeatures.value.length
-      ? [
-          {
-            type: 'application/ld+json',
-            innerHTML: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'CollectionPage',
-              'name': `${categoryName} — ${themeTitle}`,
-              'mainEntity': {
-                '@type': 'ItemList',
-                'itemListElement': namedCategoryFeatures.value.slice(0, 100).map((poi, index) => ({
-                  '@type': 'ListItem',
-                  'position': index + 1,
-                  'name': poi.properties.name?.['fr-FR'] || poi.properties.name?.fr,
-                  'url': `${origin}/poi/${poi.properties.metadata.id}/details`,
-                })),
-              },
-            }),
+  return {
+    script: [
+      {
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'CollectionPage',
+          'name': `${categoryName} — ${themeTitle}`,
+          'mainEntity': {
+            '@type': 'ItemList',
+            'itemListElement': namedCategoryFeatures.value.slice(0, 100).map((poi, index) => ({
+              '@type': 'ListItem',
+              'position': index + 1,
+              'name': poi.properties.name?.['fr-FR'] || poi.properties.name?.fr,
+              'url': `${requestOrigin}/poi/${poi.properties.metadata.id}/details`,
+            })),
           },
-        ]
-      : [],
-  }))
-}
+        }),
+      },
+    ],
+  }
+})
 
 if (status.value === 'success' && data.value && mainPoi.value) {
   poiDepsCompo.processPoiDeps(data.value, mainPoi.value.properties.metadata.id, selectedCategoryIds.value)

--- a/pages/poi/[id]/details.vue
+++ b/pages/poi/[id]/details.vue
@@ -16,6 +16,7 @@ definePageMeta({
 })
 
 const { articles, settings, theme } = storeToRefs(useSiteStore())
+const menuStore = useMenuStore()
 const { params } = useRoute()
 const { $trackingInit } = useNuxtApp()
 const apiEndpoint = useState('api-endpoint')
@@ -82,7 +83,6 @@ if (settings.value && theme.value) {
 
   const origin = useRequestURL().origin
   const categoryId = poi.value?.properties.metadata.category_ids?.[0]
-  const menuStore = useMenuStore()
   const category = categoryId ? menuStore.getCurrentCategory(categoryId) : undefined
 
   useHead({

--- a/pages/poi/[id]/details.vue
+++ b/pages/poi/[id]/details.vue
@@ -4,6 +4,7 @@ import PoiDetails from '~/components/PoisDetails/PoiDetails.vue'
 import type { ApiPoiDepsCollection } from '~/types/api/poi-deps'
 import { headerFromSettings } from '~/lib/apiSettings'
 import { useSiteStore } from '~/stores/site'
+import { menuStore as useMenuStore } from '~/stores/menu'
 import { regexForPOIIds } from '~/composables/useIdsResolver'
 import type { PoiUnion } from '~/types/local/poi-deps'
 import type { Poi } from '~/types/local/poi'
@@ -78,6 +79,28 @@ if (settings.value && theme.value) {
       },
     ),
   )
+
+  const origin = useRequestURL().origin
+  const categoryId = poi.value?.properties.metadata.category_ids?.[0]
+  const menuStore = useMenuStore()
+  const category = categoryId ? menuStore.getCurrentCategory(categoryId) : undefined
+
+  useHead({
+    script: [
+      {
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          'itemListElement': [
+            { '@type': 'ListItem', 'position': 1, 'name': theme.value.title?.fr ?? '', 'item': `${origin}/` },
+            ...(category ? [{ '@type': 'ListItem', 'position': 2, 'name': category.category.name.fr, 'item': `${origin}/${categoryId}/` }] : []),
+            { '@type': 'ListItem', 'position': category ? 3 : 2, 'name': featureSeoTitle.value },
+          ],
+        }),
+      },
+    ],
+  })
 }
 
 onBeforeMount(() => {


### PR DESCRIPTION
## Summary
- Contextual `<h1>` in Home component: shows "Category — Site name" on single-category pages, "Site name" otherwise
- Visually-hidden (`tw-sr-only`) `<ul>` with POI links on single-category pages for crawler indexing (nameless POIs filtered out)
- `CollectionPage` + `ItemList` JSON-LD structured data on category pages
- `BreadcrumbList` JSON-LD structured data on POI detail pages (Home → Category → POI)

Closes #737

## Test plan
- [x] `yarn nuxi typecheck .` passes
- [x] `yarn lint:js` passes
- [ ] `yarn build` succeeds
- [ ] View source of `/{categoryId}/` route — verify hidden `<ul>` and JSON-LD script tag
- [ ] View source of `/poi/{id}/details` route — verify BreadcrumbList JSON-LD script tag
- [ ] Validate JSON-LD at https://validator.schema.org/