### PR TITLE
fix(global-filters): keep root-level filters visible on navigation

### DIFF
--- a/components/Home/Menu.vue
+++ b/components/Home/Menu.vue
@@ -73,6 +73,12 @@ const hasSlot = computed((): boolean => {
   return slots.default !== undefined
 })
 
+const rootGlobalFiltersMap = computed(() => {
+  return getMenuItemByParentId(undefined)
+    .filter(item => 'menu_group' in item && globalFilters.value[item.id]?.length > 0)
+    .map(item => ({ id: item.id, filtersValues: globalFilters.value[item.id] }))
+})
+
 watch(currentMenuItems, () => {
   emit('scrollTop')
 })
@@ -227,8 +233,9 @@ function onClickUnselectAll(): void {
       />
 
       <GlobalFiltersCollapsible
-        v-if="currentParent && 'menu_group' in currentParent && globalFilters[currentParent.id]?.length > 0"
-        :filters-map="[{ id: currentParent.id, filtersValues: globalFilters[currentParent.id] }]"
+        v-for="entry in rootGlobalFiltersMap"
+        :key="`global-filter-${entry.id}`"
+        :filters-map="[entry]"
         @activate-filter="$emit('activateFilter', $event)"
       />
 

--- a/components/Home/Menu.vue
+++ b/components/Home/Menu.vue
@@ -73,10 +73,20 @@ const hasSlot = computed((): boolean => {
   return slots.default !== undefined
 })
 
-const rootGlobalFiltersMap = computed(() => {
-  return getMenuItemByParentId(undefined)
-    .filter(item => 'menu_group' in item && globalFilters.value[item.id]?.length > 0)
-    .map(item => ({ id: item.id, filtersValues: globalFilters.value[item.id] }))
+const rootAncestorGlobalFilters = computed(() => {
+  const firstItem = navigationStore.navigationStack[0]
+  if (!firstItem)
+    return null
+
+  // Traverse up to find the root-level ancestor (parent_id 0/null/undefined = root)
+  let ancestorId: number = firstItem.id
+  while (menuItems.value?.[ancestorId]?.parent_id) {
+    ancestorId = menuItems.value[ancestorId].parent_id!
+  }
+
+  if (!globalFilters.value[ancestorId]?.length)
+    return null
+  return { id: ancestorId, filtersValues: globalFilters.value[ancestorId] }
 })
 
 watch(currentMenuItems, () => {
@@ -233,9 +243,14 @@ function onClickUnselectAll(): void {
       />
 
       <GlobalFiltersCollapsible
-        v-for="entry in rootGlobalFiltersMap"
-        :key="`global-filter-${entry.id}`"
-        :filters-map="[entry]"
+        v-if="rootAncestorGlobalFilters && rootAncestorGlobalFilters.id !== currentParent?.id"
+        :filters-map="[rootAncestorGlobalFilters]"
+        @activate-filter="$emit('activateFilter', $event)"
+      />
+
+      <GlobalFiltersCollapsible
+        v-if="currentParent && 'menu_group' in currentParent && globalFilters[currentParent.id]?.length > 0"
+        :filters-map="[{ id: currentParent.id, filtersValues: globalFilters[currentParent.id] }]"
         @activate-filter="$emit('activateFilter', $event)"
       />
 


### PR DESCRIPTION

[Screencast_20260312_170256.webm](https://github.com/user-attachments/assets/7172aca1-9406-4acc-a372-adcf45fc1ad3)


## Summary

- Keep root-level global filters visible when navigating into nested menu groups
- Only show the filters from the root ancestor of the current navigation path

Closes #798

## Implementation

Added a `rootAncestorGlobalFilters` computed that traverses up the `parent_id` chain from `navigationStack[0]` to find the root-level menu group, then renders that group's global filters in the sub-menu view.

## Test plan

- [ ] Set a global filter on a root menu group
- [ ] Navigate into a nested menu group within that root group
- [ ] Verify the root group's filters remain visible
- [ ] Navigate into a different root group's nested items — verify only that group's filters show
- [ ] Return to root menu — verify filters display as before