### PR TITLE
fix(map): guard features watcher until style is loaded

### DIFF
--- a/components/MainMap/MapFeatures.vue
+++ b/components/MainMap/MapFeatures.vue
@@ -94,7 +94,7 @@ const availableStyles = computed((): MapStyleEnum[] => {
 watch(
   () => props.features,
   () => {
-    if (!map.value || isProcessing.value)
+    if (!map.value || !mapStyleLoaded.value || isProcessing.value)
       return
 
     showVectorSelectedFeature()


### PR DESCRIPTION
## Summary
- Adds `!mapStyleLoaded.value` guard to the features watcher in `MapFeatures.vue`
- Prevents `Style is not done loading` errors when features update before the map style is ready

Closes #806

## Test plan
- [ ] Verify features render correctly after map style loads
- [ ] Verify no `Style is not done loading` errors in console