### PR TITLE
fix(pages): add optional chaining for category name access

### DIFF
--- a/pages/embedded.vue
+++ b/pages/embedded.vue
@@ -95,7 +95,7 @@ if (settings.value && theme.value) {
     settings.value!.icon_font_css_url,
     {
       title: selectedCategories.value?.length === 1
-        ? selectedCategories.value[0].category.name.fr
+        ? selectedCategories.value[0]?.category?.name?.fr
         : undefined,
     },
   ))

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -92,7 +92,7 @@ if (settings.value && theme.value) {
     settings.value!.icon_font_css_url,
     {
       title: selectedCategories.value?.length === 1
-        ? selectedCategories.value[0].category.name.fr
+        ? selectedCategories.value[0]?.category?.name?.fr
         : undefined,
     },
   ))


### PR DESCRIPTION
## Summary
- Adds optional chaining when accessing `selectedCategories.value[0]?.category?.name?.fr` in `pages/index.vue` and `pages/embedded.vue`
- Prevents `Cannot read properties of undefined (reading 'name')` errors

Closes #807

## Test plan
- [ ] Verify page title is set correctly when a single category is selected
- [ ] Verify no crash when `selectedCategories` contains entries with missing category/name