### PR TITLE
fix(poi-deps): skip captureMessage noise for waypoints

### DIFF
--- a/composables/usePoiDeps.ts
+++ b/composables/usePoiDeps.ts
@@ -118,7 +118,8 @@ export function usePoiDeps() {
 
       if (!catId) {
         catId = mainPoi.properties.metadata.category_ids?.[0]
-        captureMessage(`Feature ${feature.properties.metadata.id} has no category_ids, falling back to main POI category`, 'warning')
+        if (!isWaypoint(feature))
+          captureMessage(`Feature ${feature.properties.metadata.id} has no category_ids, falling back to main POI category`, 'warning')
       }
 
       if (!catId)


### PR DESCRIPTION
## Summary
- Skips `captureMessage` for waypoints that legitimately lack `category_ids` in `usePoiDeps.ts`
- Keeps Sentry reporting for regular/related POIs that are missing category IDs

Closes #808

## Test plan
- [ ] Verify waypoints with no `category_ids` no longer trigger Sentry messages
- [ ] Verify regular POIs missing `category_ids` still report to Sentry