### PR TITLE
fix(poi-deps): skip unresolvable category instead of crashing SSR

### DIFF
--- a/composables/usePoiDeps.ts
+++ b/composables/usePoiDeps.ts
@@ -113,7 +113,7 @@ export function usePoiDeps() {
       })
       : collection.features
 
-    return sortedFeatures.map((feature) => {
+    return sortedFeatures.flatMap((feature) => {
       let catId = feature.properties.metadata.category_ids?.[0]
 
       if (!catId) {
@@ -131,8 +131,10 @@ export function usePoiDeps() {
         category = menuStore.getCurrentCategory(mainPoi.properties.metadata.category_ids?.[0] as number)
       }
 
-      if (!category)
-        throw createError(`Category ${catId} not found.`)
+      if (!category) {
+        captureMessage(`Category ${catId} not found, skipping feature ${feature.properties.metadata.id}`, 'warning')
+        return []
+      }
 
       return formatPoiDeps(feature, category)
     })


### PR DESCRIPTION
## Summary
- Replaces `throw createError()` with `return []` + `captureMessage` when a category cannot be resolved in `formatPoiDepsCollection`
- Uses `flatMap` to filter out skipped features
- Prevents SSR crashes while still tracking occurrences in Sentry

Closes #809

## Test plan
- [ ] Verify POI deps render correctly when all categories are found
- [ ] Verify no SSR crash when a category is missing from the menu
- [ ] Verify Sentry receives a warning message for skipped features