### PR TITLE
fix(bbox): validate bbox output to prevent Invalid LngLat

### DIFF
--- a/components/Home/Home.vue
+++ b/components/Home/Home.vue
@@ -115,8 +115,11 @@ onMounted(() => {
     origin: OriginEnum[router.currentRoute.value.query.origin as keyof typeof OriginEnum],
   })
 
-  if (props.boundaryArea || settings.value?.bbox_line)
-    initialBbox.value = getBBox({ type: 'Feature', geometry: (props.boundaryArea || settings.value!.bbox_line)!, properties: {} })
+  if (props.boundaryArea || settings.value?.bbox_line) {
+    const bounds = getBBox({ type: 'Feature', geometry: (props.boundaryArea || settings.value!.bbox_line)!, properties: {} })
+    if (bounds)
+      initialBbox.value = bounds
+  }
 })
 
 onBeforeUnmount(() => {

--- a/lib/bbox.ts
+++ b/lib/bbox.ts
@@ -4,8 +4,11 @@ import { bbox as turfBbox } from '@turf/bbox'
 
 type ITLngLatBounds = InstanceType<typeof LngLatBounds>
 
-export function getBBox(data: GeoJSON.Feature | GeoJSON.FeatureCollection): LngLatBounds {
+export function getBBox(data: GeoJSON.Feature | GeoJSON.FeatureCollection): LngLatBounds | undefined {
   const bbox = turfBbox(data)
+
+  if (!bbox.every(v => Number.isFinite(v)))
+    return undefined
 
   return new LngLatBounds(
     [bbox[0], bbox[1]],


### PR DESCRIPTION
## Summary
- Validates `getBBox()` output to return `undefined` when coordinates are invalid (NaN, Infinity)
- Guards assignment in `Home.vue` to skip setting bounds when bbox is invalid

Closes #805

## Test plan
- [ ] Verify map loads normally with valid data
- [ ] Verify no crash when bbox computation returns invalid coordinates