### PR TITLE
feat(filters): add title tooltip on filter collapse button

### DIFF
--- a/components/Menu/GlobalFiltersCollapsible.vue
+++ b/components/Menu/GlobalFiltersCollapsible.vue
@@ -24,6 +24,7 @@ const isFiltered = computed(() => {
   <div class="tw-flex tw-flex-col">
     <button
       type="button"
+      :title="t('headerMenu.filterTitle')"
       class="tw-flex tw-items-center tw-w-full tw-h-12 sm:tw-h-8 tw-text-left tw-cursor-pointer tw-rounded-lg tw-outline-none focus:tw-outline-none tw-transition-colors hover:tw-bg-zinc-100"
       :class="[
         isFiltered ? 'tw-text-emerald-500' : 'tw-text-zinc-500',

--- a/locales/en-GB.ts
+++ b/locales/en-GB.ts
@@ -63,6 +63,7 @@ export default defineI18nLocale(() => {
       selectAll: 'Select all',
       unselectAll: 'Unselect all',
       filter: 'Filter',
+      filterTitle: 'The filter will only apply to selected categories',
       editFilters: 'Edit filters',
       categories: 'Categories',
       cities: 'Cities',

--- a/locales/es-ES.ts
+++ b/locales/es-ES.ts
@@ -63,6 +63,7 @@ export default defineI18nLocale(() => {
       selectAll: 'Seleccionar todo',
       unselectAll: 'Deseleccionar todo',
       filter: 'Filtro',
+      filterTitle: 'El filtro solo se aplicará a las categorías seleccionadas',
       editFilters: 'Editar filtros',
       categories: 'Categorías',
       cities: 'Comunas',

--- a/locales/fr-FR.ts
+++ b/locales/fr-FR.ts
@@ -64,6 +64,7 @@ export default defineI18nLocale(() => {
       selectAll: 'Tout sélectionner',
       unselectAll: 'Tout désélectionner',
       filter: 'Filtrer',
+      filterTitle: 'Le filtre s\'appliquera uniquement aux catégories sélectionnées',
       editFilters: 'Modifier les filtres',
       categories: 'Catégories',
       cities: 'Communes',


### PR DESCRIPTION
## Summary
- Add a `title` attribute on the filter collapse button in `GlobalFiltersCollapsible.vue` to display a tooltip on hover
- Add the i18n translation key `headerMenu.filterTitle` in all three locales:
  - FR: "Le filtre s'appliquera uniquement aux catégories sélectionnées"
  - EN: "The filter will only apply to selected categories"
  - ES: "El filtro solo se aplicará a las categorías seleccionadas"

Closes #816