### PR TITLE
fix(search): close dropdown when input is fully cleared

### DIFF
--- a/stores/search.ts
+++ b/stores/search.ts
@@ -137,15 +137,17 @@ export const useSearchStore = defineStore('search', () => {
   }
 
   function submit(value: string): void {
+    searchText.value = value
+
     if (!value || !value.trim().length) {
+      searchQueryId.value += 1
+      searchResultId.value = searchQueryId.value
       searchMenuItemsResults.value = null
       searchPoisResults.value = null
       searchAddressesResults.value = null
       searchCartocodeResult.value = null
       return
     }
-
-    searchText.value = value
 
     // Launch search if not already loading + search text length >= 3
     if (!isLoading.value && searchText.value.trim().length >= 3)


### PR DESCRIPTION
## Summary
- Move `searchText.value` assignment before the early return in `submit()` so the store stays in sync with the input
- Bump `searchQueryId` / `searchResultId` on clear to invalidate in-flight API responses that would otherwise repopulate the dropdown

## Test plan
- [ ] Type a search query, wait for results to appear
- [ ] Clear the input completely — dropdown should disappear
- [ ] Clear the input quickly while results are still loading — dropdown should not reappear

Closes #821