### PR TITLE
fix(deps): crash and missing PoiCard with cross-theme categories

### DIFF
--- a/components/MainMap/MapFeatures.vue
+++ b/components/MainMap/MapFeatures.vue
@@ -270,7 +270,8 @@ async function updateSelectedFeature(feature?: PoiUnion): Promise<void> {
 
           const poi = data.value.find(f => f.properties.metadata.id === id)
           // In case user click on vecto element, attach Pin Marker to POI Marker
-          teritorioCluster.value?.setSelectedFeature(poi as unknown as GeoJSONFeature)
+          if (poi)
+            teritorioCluster.value?.setSelectedFeature(poi as unknown as GeoJSONFeature)
         }
       }
       catch (e) {

--- a/composables/usePoiDeps.ts
+++ b/composables/usePoiDeps.ts
@@ -132,8 +132,9 @@ export function usePoiDeps() {
         category = menuStore.getCurrentCategory(mainPoi.properties.metadata.category_ids?.[0] as number)
       }
 
-      if (!category) {
-        // Fallback to currently selected categories (e.g. POI accessible via category 9050 but deps returns category 45827)
+      if (!category && feature.properties.metadata.id === mainPoiId) {
+        // Fallback to currently selected categories for the main POI only
+        // (e.g. POI accessible via category 9050 but deps returns category 45827)
         for (const selectedId of menuStore.selectedCategoryIds) {
           category = menuStore.getCurrentCategory(selectedId)
           if (category)

--- a/composables/usePoiDeps.ts
+++ b/composables/usePoiDeps.ts
@@ -133,6 +133,15 @@ export function usePoiDeps() {
       }
 
       if (!category) {
+        // Fallback to currently selected categories (e.g. POI accessible via category 9050 but deps returns category 45827)
+        for (const selectedId of menuStore.selectedCategoryIds) {
+          category = menuStore.getCurrentCategory(selectedId)
+          if (category)
+            break
+        }
+      }
+
+      if (!category) {
         captureMessage(`Category ${catId} not found, skipping feature ${feature.properties.metadata.id}`, 'warning')
         return []
       }

--- a/server/plugins/image-domains.ts
+++ b/server/plugins/image-domains.ts
@@ -9,16 +9,17 @@ export default defineNitroPlugin(async () => {
     const domains = Object.fromEntries(
       Object.entries(configs).map(([slug, config]) => {
         const urls = Object.values(config.themes)
-          .map((theme) => {
-            return [
-              new URL(theme.site_url?.fr || '').host,
-              import.meta.dev
-                ? `${theme.slug}-${slug}.${new URL(genericApiEndpoint).host}`
-                : `${theme.slug}-${slug}.${appHost}`,
-            ]
+          .flatMap((theme) => {
+            const siteUrl = theme.site_url?.fr
+            const devOrProdHost = import.meta.dev
+              ? `${theme.slug}-${slug}.${new URL(genericApiEndpoint).host}`
+              : `${theme.slug}-${slug}.${appHost}`
+
+            if (!siteUrl)
+              return [devOrProdHost]
+
+            return [new URL(siteUrl).host, devOrProdHost]
           })
-          .filter(Boolean)
-          .flat()
 
         const imageHosts = Array.isArray(config.image_proxy_hosts)
           ? config.image_proxy_hosts

--- a/server/plugins/image-domains.ts
+++ b/server/plugins/image-domains.ts
@@ -18,7 +18,12 @@ export default defineNitroPlugin(async () => {
             if (!siteUrl)
               return [devOrProdHost]
 
-            return [new URL(siteUrl).host, devOrProdHost]
+            try {
+              return [new URL(siteUrl).host, devOrProdHost]
+            }
+            catch {
+              return [devOrProdHost]
+            }
           })
 
         const imageHosts = Array.isArray(config.image_proxy_hosts)

--- a/stores/menu.ts
+++ b/stores/menu.ts
@@ -155,11 +155,14 @@ export const menuStore = defineStore('menu', () => {
 
   const getCurrentCategory = computed((): (categoryId: number) => MenuCategory | undefined => {
     return (categoryId) => {
-      return menuItems.value === undefined
-        ? undefined
-        : Object.values(menuItems.value).find(
-          menuItem => menuItem.id === categoryId,
-        ) as MenuCategory
+      if (menuItems.value === undefined)
+        return undefined
+
+      const menuItem = menuItems.value[categoryId]
+      if (menuItem && 'category' in menuItem)
+        return menuItem as MenuCategory
+
+      return undefined
     }
   })
 


### PR DESCRIPTION
## Summary
- **getCurrentCategory type safety**: only return items with `'category'` key, preventing crash when a dep's `category_id` matches a `MenuGroup` or `MenuLink`
- **Optional site_url handling**: skip `site_url` host in `image-domains.ts` when absent, preventing `Invalid URL` crash on dev server startup
- **Cross-theme category fallback**: guard `setSelectedFeature` against `undefined` and fall back to currently selected categories when deps `category_ids` don't match any menu category — fixes crash and missing PoiCard

## Test plan
- [ ] On routesgourmandes theme, navigate to category 9050, click a POI on the map → PoiCard should open without console errors
- [ ] Click POI 63094 (cross-theme: `category_ids: [63188, 9050]`) → no crash, deps display correctly
- [ ] Start dev server with `NUXT_PUBLIC_GENERIC_API_ENDPOINT` pointing to production → no `Invalid URL` crash

Fixes #825