### PR TITLE
fix(map): enable clustering in RouteMap for overlapping waypoints

### DIFF
--- a/components/PoisDetails/Route/RouteMap.vue
+++ b/components/PoisDetails/Route/RouteMap.vue
@@ -95,7 +95,6 @@ const pois = computed(() => props.poiDeps.filter(f => !poiDepsCompo.isWaypoint(f
       :feature-ids="featureDepsIDs"
       :fullscreen-control="true"
       :off-map-attribution="true"
-      :cluster="false"
     />
     <div class="detail-wrapper">
       <div v-if="waypoints.length > 0" class="detail-left">


### PR DESCRIPTION
## Summary
- Remove `cluster: false` from `RouteMap` so that `TeritorioCluster` can unfold features sharing the same coordinates
- Waypoints at the same location as POIs (e.g. Gabarret) are now displayed as distinct markers via the unfolded cluster rendering

## Test plan
- [ ] Open a route POI detail page that has waypoints sharing coordinates with POIs
- [ ] Verify both the POI marker and the waypoint marker are visible on the RouteMap
- [ ] Verify clicking on a waypoint marker still opens its popup correctly
- [ ] Verify route line rendering is unaffected

Closes #828