### PR TITLE
fix(map): show route action button in NavigationDrawer on mobile

### DIFF
--- a/components/Map/MapPois.vue
+++ b/components/Map/MapPois.vue
@@ -154,7 +154,7 @@ function transformApiPoi(feature: ApiPoi): Poi {
           </template>
           <VCardText>
             <PoiCardContent
-              :show-actions="false"
+              :show-actions="true"
               :show-only-route-action="true"
               :details-is-external="true"
               :poi="selectedFeature"


### PR DESCRIPTION
## Summary

- Restore `show-actions` to `true` in `MapPois.vue` NavigationDrawer so the route action button is visible on mobile
- The prop was accidentally set back to `false` during a template refactor in `a000273b`, hiding the entire actions bar and making `show-only-route-action` ineffective

## Root Cause

Regression introduced in commit `a000273b` (11 Dec 2025) when the `<VLayout>` wrapper was removed: `:show-actions` was reset to `false` instead of staying `true` as set in the original commit `f4043cce`.

Closes #830