### PR TITLE
fix(layout): propagate real API error details instead of generic Nuxt 500

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -63,7 +63,13 @@ const { data, error, status } = await useAsyncData('parallel', async () => {
 })
 
 if (error.value) {
-  throw createError(error.value)
+  const err = error.value as Error & { statusCode?: number, statusMessage?: string, data?: unknown }
+  throw createError({
+    statusCode: err.statusCode || 500,
+    statusMessage: err.statusMessage || err.message,
+    data: err.data,
+    fatal: true,
+  })
 }
 
 if (status.value === 'success' && data.value) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { FetchError } from 'ofetch'
 import { storeToRefs } from 'pinia'
 import type { Settings } from '~/lib/apiSettings'
 import type { PropertyTranslations } from '~/lib/apiPropertyTranslations'
@@ -18,7 +19,13 @@ const { data: context, error: configError } = await useFetch('/api/config', {
 })
 
 if (configError.value) {
-  showError({ ...configError.value })
+  const err = configError.value as FetchError
+  showError({
+    statusCode: err.statusCode || 500,
+    statusMessage: err.statusMessage || err.message,
+    data: err.data,
+    cause: err,
+  })
 }
 
 const apiEndpoint = useState('api-endpoint', () => context.value?.api)
@@ -63,11 +70,12 @@ const { data, error, status } = await useAsyncData('parallel', async () => {
 })
 
 if (error.value) {
-  const err = error.value as Error & { statusCode?: number, statusMessage?: string, data?: unknown }
+  const err = error.value as FetchError
   throw createError({
     statusCode: err.statusCode || 500,
     statusMessage: err.statusMessage || err.message,
     data: err.data,
+    cause: err,
     fatal: true,
   })
 }


### PR DESCRIPTION
## Summary

- Explicitly extract `statusCode`, `statusMessage`, and `data` from the `FetchError` before calling `createError()` in `layouts/default.vue`
- Adds `fatal: true` so Nuxt renders the full error page
- HTTP errors from the remote API (e.g. 503) are now forwarded with the correct status code and the raw response body
- Network errors (ECONNRESET) still produce a 500 but with the actual error message instead of the generic `"fetch failed"`

Fixes #832

## Root cause

`useAsyncData` types `error.value` as plain `Error`. Passing it directly to `createError()` loses the `FetchError` fields (`statusCode`, `statusMessage`, `data`), causing Nuxt to always default to 500 with no meaningful message.

## Changes

`layouts/default.vue` — cast `error.value` to expose `FetchError` fields and pass them explicitly to `createError()`.