### PR TITLE
fix(error): show error page instead of blank page when API is down

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -19,7 +19,7 @@ const handleError = () => reloadNuxtApp({ path: '/' })
       <VEmptyState
         v-if="error"
         color="elevated"
-        :image="logoUrl"
+        :image="logoUrl || undefined"
         :headline="$t('error.statusCode', { status: error.statusCode })"
         :text="error.message"
         :action-text="$t('error.backHome')"

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { FetchError } from 'ofetch'
 import { storeToRefs } from 'pinia'
 import type { Settings } from '~/lib/apiSettings'
 import { useSiteStore } from '~/stores/site'
@@ -12,7 +13,13 @@ const { data: context, error: configError } = await useFetch('/api/config', {
 })
 
 if (configError.value) {
-  showError({ ...configError.value })
+  const err = configError.value as FetchError
+  showError({
+    statusCode: err.statusCode || 500,
+    statusMessage: err.statusMessage || err.message,
+    data: err.data,
+    cause: err,
+  })
 }
 
 const { settings } = storeToRefs(useSiteStore())

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -19,10 +19,7 @@ const { settings } = storeToRefs(useSiteStore())
 const apiEndpoint = useState('api-endpoint', () => context.value?.api)
 
 if (apiEndpoint.value) {
-  const { data, error, status } = await useAsyncData('parallel', async () => $fetch<Settings>(`${apiEndpoint.value}/settings.json`))
-
-  if (error.value)
-    throw createError(error.value)
+  const { data, status } = await useAsyncData('error-layout-settings', async () => $fetch<Settings>(`${apiEndpoint.value}/settings.json`))
 
   if (status.value === 'success' && data.value) {
     settings.value = Object.assign(

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,26 +1,15 @@
 <script setup lang="ts">
-import type { FetchError } from 'ofetch'
 import { storeToRefs } from 'pinia'
 import type { Settings } from '~/lib/apiSettings'
 import { useSiteStore } from '~/stores/site'
 
 const { detectHost } = useHostDetection()
 
-const { data: context, error: configError } = await useFetch('/api/config', {
+const { data: context } = await useFetch('/api/config', {
   headers: {
     'x-client-host': detectHost(),
   },
 })
-
-if (configError.value) {
-  const err = configError.value as FetchError
-  showError({
-    statusCode: err.statusCode || 500,
-    statusMessage: err.statusMessage || err.message,
-    data: err.data,
-    cause: err,
-  })
-}
 
 const { settings } = storeToRefs(useSiteStore())
 const apiEndpoint = useState('api-endpoint', () => context.value?.api)


### PR DESCRIPTION
## Summary

- Fix blank page shown instead of the error page when the backend API returns 5xx
- Rename `useAsyncData` key in `layouts/error.vue` from `'parallel'` to `'error-layout-settings'` to avoid inheriting the cached error from the default layout
- Remove the `throw createError()` call in the error layout so it renders gracefully even when settings cannot be fetched
- Use `logoUrl || undefined` in `error.vue` to avoid a broken `<img>` tag when the site store was never initialized

## Root cause

Two bugs combined to produce the blank page:

1. `layouts/error.vue` shared the key `'parallel'` with `layouts/default.vue` — the error layout immediately inherited the cached 502 error
2. `layouts/error.vue` called `throw createError()` from within the error rendering context — Nuxt cannot handle an error thrown while already rendering the error page, resulting in a blank screen

Closes #836

## Test plan

- [ ] Simulate a backend API outage (stop the API or point `NUXT_PUBLIC_API_ENDPOINT` to an unreachable URL)
- [ ] Navigate to the app root — the error page should render with the error status code and a "Back to map" button
- [ ] Confirm no blank page and no console errors related to `useAsyncData` key conflicts