### PR TITLE
refactor(error): extract createFetchError helper and apply across all call sites

### DIFF
--- a/components/MainMap/MapFeatures.vue
+++ b/components/MainMap/MapFeatures.vue
@@ -256,7 +256,7 @@ async function updateSelectedFeature(feature?: PoiUnion): Promise<void> {
           return
 
         if (error.value)
-          throw createError(error.value)
+          throw createFetchError(error.value, true)
 
         if (status.value === 'success' && data.value) {
           if (!isDepSelected) {

--- a/components/MainMap/MapFeatures.vue
+++ b/components/MainMap/MapFeatures.vue
@@ -256,7 +256,7 @@ async function updateSelectedFeature(feature?: PoiUnion): Promise<void> {
           return
 
         if (error.value)
-          throw createFetchError(error.value, true)
+          throw createFetchError(error.value)
 
         if (status.value === 'success' && data.value) {
           if (!isDepSelected) {

--- a/components/Map/MapPois.vue
+++ b/components/Map/MapPois.vue
@@ -99,7 +99,7 @@ function renderPois(): void {
     )
 
     if (error.value)
-      throw createError(error.value)
+      throw createFetchError(error.value, true)
 
     if (status.value === 'success' && data.value) {
       mapStore.setSelectedFeature(data.value)

--- a/components/Map/MapPois.vue
+++ b/components/Map/MapPois.vue
@@ -99,7 +99,7 @@ function renderPois(): void {
     )
 
     if (error.value)
-      throw createFetchError(error.value, true)
+      throw createFetchError(error.value)
 
     if (status.value === 'success' && data.value) {
       mapStore.setSelectedFeature(data.value)

--- a/composables/useIsochrone.ts
+++ b/composables/useIsochrone.ts
@@ -173,7 +173,7 @@ export default function useIsochrone() {
     )
 
     if (error.value)
-      throw createError(error.value)
+      throw createFetchError(error.value, true)
 
     if (data.value) {
       isochroneCurrentFeature.value = feature

--- a/composables/usePois.ts
+++ b/composables/usePois.ts
@@ -35,7 +35,7 @@ export function usePois() {
     )
 
     if (err.value)
-      createError(error.value)
+      throw createFetchError(err.value, true)
 
     if (stat.value === 'success' && data.value) {
       pois.value = data.value

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { FetchError } from 'ofetch'
 import { storeToRefs } from 'pinia'
 import type { Settings } from '~/lib/apiSettings'
 import type { PropertyTranslations } from '~/lib/apiPropertyTranslations'
@@ -19,13 +18,7 @@ const { data: context, error: configError } = await useFetch('/api/config', {
 })
 
 if (configError.value) {
-  const err = configError.value as FetchError
-  showError({
-    statusCode: err.statusCode || 500,
-    statusMessage: err.statusMessage || err.message,
-    data: err.data,
-    cause: err,
-  })
+  showError(createFetchError(configError.value))
 }
 
 const apiEndpoint = useState('api-endpoint', () => context.value?.api)
@@ -70,14 +63,7 @@ const { data, error, status } = await useAsyncData('parallel', async () => {
 })
 
 if (error.value) {
-  const err = error.value as FetchError
-  throw createError({
-    statusCode: err.statusCode || 500,
-    statusMessage: err.statusMessage || err.message,
-    data: err.data,
-    cause: err,
-    fatal: true,
-  })
+  throw createFetchError(error.value, true)
 }
 
 if (status.value === 'success' && data.value) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -18,7 +18,7 @@ const { data: context, error: configError } = await useFetch('/api/config', {
 })
 
 if (configError.value) {
-  showError(createFetchError(configError.value))
+  throw createFetchError(configError.value, true)
 }
 
 const apiEndpoint = useState('api-endpoint', () => context.value?.api)

--- a/pages/articles/[slug].vue
+++ b/pages/articles/[slug].vue
@@ -25,7 +25,7 @@ const { params } = useRoute()
 const { data, error, status } = await getArticle(params.slug as string)
 
 if (error.value)
-  throw createError(error.value)
+  throw createFetchError(error.value, true)
 
 const content = ref<string>()
 onMounted(() => {

--- a/pages/embedded.vue
+++ b/pages/embedded.vue
@@ -124,7 +124,7 @@ const { data, error, status } = await useAsyncData('features', async () => {
 })
 
 if (error.value)
-  throw createError(error.value)
+  throw createFetchError(error.value, true)
 
 if (status.value === 'success' && data.value && mainPoi.value) {
   poiDepsCompo.processPoiDeps(data.value, mainPoi.value.properties.metadata.id, selectedCategoryIds.value)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -126,7 +126,7 @@ const { data, error, status } = await useAsyncData('features', async () => {
 })
 
 if (error.value)
-  throw createError(error.value)
+  throw createFetchError(error.value, true)
 
 const requestOrigin = useRequestURL().origin
 

--- a/pages/poi/[id]/details.vue
+++ b/pages/poi/[id]/details.vue
@@ -43,7 +43,7 @@ const { data, error, status } = await useFetch(
 )
 
 if (error.value) {
-  throw createError(error.value)
+  throw createFetchError(error.value, true)
 }
 
 if (status.value === 'success' && data.value) {

--- a/pages/pois/[ids]/map.vue
+++ b/pages/pois/[ids]/map.vue
@@ -103,7 +103,7 @@ const { data, error } = await useAsyncData('pois-map', async () => {
 })
 
 if (error.value) {
-  throw createError(error.value)
+  throw createFetchError(error.value, true)
 }
 
 if (!data.value?.length) {

--- a/utils/fetchError.ts
+++ b/utils/fetchError.ts
@@ -1,0 +1,12 @@
+import type { FetchError } from 'ofetch'
+
+export function createFetchError(err: unknown, fatal = false) {
+  const fetchErr = err as FetchError
+  return createError({
+    statusCode: fetchErr.statusCode || 500,
+    statusMessage: fetchErr.statusMessage || fetchErr.message,
+    data: fetchErr.data,
+    cause: fetchErr,
+    fatal,
+  })
+}


### PR DESCRIPTION
## Summary

- Extract a shared `createFetchError(err, fatal?)` helper in `utils/fetchError.ts` (auto-imported by Nuxt) that properly maps `FetchError` fields to `createError()` parameters
- Replace all 11 inline `createError(error.value)` / `showError({ ...error.value })` call sites with the helper
- Fix a pre-existing bug in `composables/usePois.ts`: `createError(error.value)` was missing `throw` and was referencing the wrong variable (`error.value` instead of `err.value`)

## Test plan

- [ ] Simulate a backend API outage — error page should show the real status code and message
- [ ] `yarn nuxi typecheck .` passes

Closes #834