### PR TITLE
fix(OpeningHours): wrap status in ClientOnly to prevent SSR/CSR hydration mismatch

### DIFF
--- a/components/Fields/OpeningHours.test.js
+++ b/components/Fields/OpeningHours.test.js
@@ -1,5 +1,5 @@
 import { createPinia } from 'pinia'
-import { createApp } from 'vue'
+import { createApp, defineComponent } from 'vue'
 import { beforeEach, expect, it } from 'mocha'
 import OpeningHours from '~/components/Fields/OpeningHours.vue'
 import { PropertyTranslationsContextEnum, useSiteStore } from '~/stores/site'
@@ -26,6 +26,12 @@ beforeEach(() => {
   })
 })
 
+const ClientOnlyStub = defineComponent({
+  setup(_, { slots }) {
+    return () => slots.default?.()
+  },
+})
+
 function factory(props = {}) {
   const el = document.createElement('div')
   createApp(OpeningHours, {
@@ -34,7 +40,7 @@ function factory(props = {}) {
     openingHours: '24/7',
     baseDate: new Date('2022-01-02 11:00:00'), // Sunday
     ...props,
-  }).use(realPinia).mount(el)
+  }).component('ClientOnly', ClientOnlyStub).use(realPinia).mount(el)
   return el
 }
 

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -165,38 +165,40 @@ function OpeningHoursFactory(): OpeningHours | undefined {
 <template>
   <div v-if="openingHours">
     <span hidden>{{ openingHours }}</span>
-    <template v-if="nextChange">
-      <p v-if="isPointTime" id="next" class="tw-text-emerald-500">
-        {{ t('openingHours.next') }}
-        <RelativeDate :date="nextChange.nextChange" />
-      </p>
-      <template v-else>
-        <p
-          v-if="nextChange.type === 'opened'"
-          id="opened"
-          class="tw-text-emerald-500"
-        >
-          {{ t('openingHours.opened') }}
-          <template v-if="nextChange.nextChange">
-            -
-            {{ t('openingHours.closeAt') }}
-            <RelativeDate :date="nextChange.nextChange" />
-          </template>
+    <ClientOnly>
+      <template v-if="nextChange">
+        <p v-if="isPointTime" id="next" class="tw-text-emerald-500">
+          {{ t('openingHours.next') }}
+          <RelativeDate :date="nextChange.nextChange" />
         </p>
-        <p
-          v-else-if="nextChange.type === 'openAt'"
-          id="openAt"
-          class="tw-text-red-500"
-        >
-          {{ t('openingHours.closed') }}
-          <template v-if="nextChange.nextChange">
-            -
-            {{ t('openingHours.openAt') }}
-            <RelativeDate :date="nextChange.nextChange" />
-          </template>
-        </p>
+        <template v-else>
+          <p
+            v-if="nextChange.type === 'opened'"
+            id="opened"
+            class="tw-text-emerald-500"
+          >
+            {{ t('openingHours.opened') }}
+            <template v-if="nextChange.nextChange">
+              -
+              {{ t('openingHours.closeAt') }}
+              <RelativeDate :date="nextChange.nextChange" />
+            </template>
+          </p>
+          <p
+            v-else-if="nextChange.type === 'openAt'"
+            id="openAt"
+            class="tw-text-red-500"
+          >
+            {{ t('openingHours.closed') }}
+            <template v-if="nextChange.nextChange">
+              -
+              {{ t('openingHours.openAt') }}
+              <RelativeDate :date="nextChange.nextChange" />
+            </template>
+          </p>
+        </template>
       </template>
-    </template>
+    </ClientOnly>
     <template v-if="!isCompact">
       <br>
       <div v-if="pretty && !pretty[0][0] && pretty[0][1].length === 1">

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -197,10 +197,10 @@ function OpeningHoursFactory(): OpeningHours | undefined {
             </template>
           </p>
         </template>
+        <br v-if="!isCompact">
       </template>
     </ClientOnly>
     <template v-if="!isCompact">
-      <br>
       <div v-if="pretty && !pretty[0][0] && pretty[0][1].length === 1">
         {{ pretty[0][1][0] }}
       </div>


### PR DESCRIPTION
## Summary

- Wraps the time-sensitive `nextChange` status block in `<ClientOnly>` inside `OpeningHours.vue` to prevent SSR rendering of the open/closed indicator
- Updates `OpeningHours.test.js` to register a transparent `<ClientOnly>` stub so existing test assertions continue to work

## Root cause

`opening_hours.js` evaluates open/closed state using JavaScript's local `Date` methods (`getHours()`, `getDay()`, etc.), which depend on the **system timezone**. When the Node.js server runs in a different timezone than the user's browser, the state computed during SSR can differ from the client's computation.

Vue 3 in production does not always fully correct such hydration mismatches: the text node updates to "Currently open" but the CSS class (`tw-text-red-500`) from the SSR render can persist — hence the red color on the details page and green on the map popup (which is always CSR-only).

## What stays SSR-rendered

The weekly schedule (Mo-Th 07:30-12:00...) and the `<span hidden>` raw value remain in the SSR output for SEO. Only the time-sensitive open/closed status is deferred to the client.

Closes #845