### PR TITLE
fix(OpeningHours): handle unknown state and suppress status for one-time events

### DIFF
--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -231,8 +231,13 @@ function OpeningHoursFactory(): OpeningHours | undefined {
         <p>{{ t('openingHours.variableWeek') }}</p>
       </template>
     </template>
-    <template v-if="isCompact && comment">
-      <p>{{ comment }}</p>
+    <template v-if="isCompact">
+      <p v-if="isEvent && pretty">
+        {{ pretty[0][1][0] }}
+      </p>
+      <p v-else-if="comment">
+        {{ comment }}
+      </p>
     </template>
   </div>
 </template>

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -100,13 +100,14 @@ const pretty = computed((): [string | undefined, string[]][] | undefined => {
   return undefined
 })
 
-const nextChange = computed((): { type: 'opened' | 'openAt', nextChange: Date } | undefined => {
+const nextChange = computed((): { type: 'opened' | 'openAt' | 'unknown', nextChange: Date } | undefined => {
   if (oh.value) {
     try {
       const nextChange = oh.value.getNextChange(props.baseDate)
       if (nextChange) {
+        const isUnknown = oh.value.getUnknown(props.baseDate)
         return {
-          type: oh.value.getState(props.baseDate) ? 'opened' : 'openAt',
+          type: isUnknown ? 'unknown' : (oh.value.getState(props.baseDate) ? 'opened' : 'openAt'),
           nextChange,
         }
       }
@@ -166,7 +167,7 @@ function OpeningHoursFactory(): OpeningHours | undefined {
   <div v-if="openingHours">
     <span hidden>{{ openingHours }}</span>
     <ClientOnly>
-      <template v-if="nextChange">
+      <template v-if="nextChange && !isEvent">
         <p v-if="isPointTime" id="next" class="tw-text-emerald-500">
           {{ t('openingHours.next') }}
           <RelativeDate :date="nextChange.nextChange" />
@@ -195,6 +196,13 @@ function OpeningHoursFactory(): OpeningHours | undefined {
               {{ t('openingHours.openAt') }}
               <RelativeDate :date="nextChange.nextChange" />
             </template>
+          </p>
+          <p
+            v-else-if="nextChange.type === 'unknown'"
+            id="unknown"
+            class="tw-text-amber-500"
+          >
+            {{ t('openingHours.unknown') }}
           </p>
         </template>
         <br v-if="!isCompact">

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -23,7 +23,7 @@ const props = withDefaults(defineProps<{
 //
 const siteStore = useSiteStore()
 const { settings } = siteStore
-const { locale, t } = useI18n()
+const { locale, t, d } = useI18n()
 
 const PointTime = ['collection_times'] as AssocRenderValue[]
 
@@ -96,6 +96,27 @@ const pretty = computed((): [string | undefined, string[]][] | undefined => {
         })
       return ret
     }
+  }
+  return undefined
+})
+
+const eventDisplay = computed((): { date: Date, end: Date | undefined, unknown: boolean } | undefined => {
+  if (!isEvent.value || !oh.value)
+    return undefined
+  try {
+    const year = props.baseDate.getFullYear()
+    const intervals = oh.value.getOpenIntervals(
+      new Date(year - 1, 0, 1),
+      new Date(year + 2, 0, 1),
+    )
+    if (intervals.length > 0) {
+      const [start, end, unknown] = intervals[0]
+      return { date: start, end: end ?? undefined, unknown }
+    }
+  }
+  catch (e) {
+    if (import.meta.dev)
+      console.warn('[OpeningHours] getOpenIntervals failed:', props.openingHours, e)
   }
   return undefined
 })
@@ -232,12 +253,29 @@ function OpeningHoursFactory(): OpeningHours | undefined {
       </template>
     </template>
     <template v-if="isCompact">
-      <p v-if="isEvent && pretty">
-        {{ pretty[0][1][0] }}
-      </p>
-      <p v-else-if="comment">
-        {{ comment }}
-      </p>
+      <ClientOnly>
+        <p v-if="isEvent && eventDisplay && !eventDisplay.unknown">
+          {{ t('openingHours.eventRange', {
+            date: d(eventDisplay.date, { dateStyle: 'short' }),
+            start: d(eventDisplay.date, { timeStyle: 'short' }),
+            end: d(eventDisplay.end!, { timeStyle: 'short' }),
+          }) }}
+        </p>
+        <p v-else-if="isEvent && eventDisplay && eventDisplay.unknown">
+          {{ t('openingHours.eventRangeOpenEnd', {
+            date: d(eventDisplay.date, { dateStyle: 'short' }),
+            start: d(eventDisplay.date, { timeStyle: 'short' }),
+          }) }}
+        </p>
+        <p v-else-if="comment">
+          {{ comment }}
+        </p>
+        <template #fallback>
+          <p v-if="isEvent && pretty">
+            {{ pretty[0][1][0] }}
+          </p>
+        </template>
+      </ClientOnly>
     </template>
   </div>
 </template>

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -230,26 +230,48 @@ function OpeningHoursFactory(): OpeningHours | undefined {
       </template>
     </ClientOnly>
     <template v-if="!isCompact">
-      <div v-if="pretty && !pretty[0][0] && pretty[0][1].length === 1">
-        {{ pretty[0][1][0] }}
-      </div>
-      <ul v-else-if="pretty && !pretty[0][0]">
-        <li v-for="(row, i) in pretty[0][1]" :key="i">
-          {{ row }}
-        </li>
-      </ul>
-      <ul v-else-if="pretty">
-        <li v-for="[month, dates] in pretty" :key="month">
-          {{ month }}
-          <ul>
-            <li v-for="(row, i) in dates" :key="i">
-              {{ row }}
-            </li>
-          </ul>
-        </li>
-      </ul>
-      <template v-if="variable && !isEvent">
-        <p>{{ t('openingHours.variableWeek') }}</p>
+      <ClientOnly v-if="isEvent">
+        <p v-if="eventDisplay && !eventDisplay.unknown">
+          {{ t('openingHours.eventRange', {
+            date: d(eventDisplay.date, { dateStyle: 'short' }),
+            start: d(eventDisplay.date, { timeStyle: 'short' }),
+            end: d(eventDisplay.end!, { timeStyle: 'short' }),
+          }) }}
+        </p>
+        <p v-else-if="eventDisplay && eventDisplay.unknown">
+          {{ t('openingHours.eventRangeOpenEnd', {
+            date: d(eventDisplay.date, { dateStyle: 'short' }),
+            start: d(eventDisplay.date, { timeStyle: 'short' }),
+          }) }}
+        </p>
+        <template #fallback>
+          <p v-if="pretty">
+            {{ pretty[0][1][0] }}
+          </p>
+        </template>
+      </ClientOnly>
+      <template v-else>
+        <div v-if="pretty && !pretty[0][0] && pretty[0][1].length === 1">
+          {{ pretty[0][1][0] }}
+        </div>
+        <ul v-else-if="pretty && !pretty[0][0]">
+          <li v-for="(row, i) in pretty[0][1]" :key="i">
+            {{ row }}
+          </li>
+        </ul>
+        <ul v-else-if="pretty">
+          <li v-for="[month, dates] in pretty" :key="month">
+            {{ month }}
+            <ul>
+              <li v-for="(row, i) in dates" :key="i">
+                {{ row }}
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <template v-if="variable">
+          <p>{{ t('openingHours.variableWeek') }}</p>
+        </template>
       </template>
     </template>
     <template v-if="isCompact">

--- a/locales/en-GB.ts
+++ b/locales/en-GB.ts
@@ -94,6 +94,8 @@ export default defineI18nLocale(() => {
       next: 'Next',
       formatDayAndDayInMonth: 'EEE do\':\'',
       unknown: 'Indicative hours',
+      eventRange: '{date} from {start} to {end}',
+      eventRangeOpenEnd: '{date} from {start}',
       variableWeek: 'The hours may vary from week to week.',
     },
     poiCard: {

--- a/locales/en-GB.ts
+++ b/locales/en-GB.ts
@@ -93,6 +93,7 @@ export default defineI18nLocale(() => {
       openAt: 'Opens',
       next: 'Next',
       formatDayAndDayInMonth: 'EEE do\':\'',
+      unknown: 'Indicative hours',
       variableWeek: 'The hours may vary from week to week.',
     },
     poiCard: {

--- a/locales/es-ES.ts
+++ b/locales/es-ES.ts
@@ -94,6 +94,8 @@ export default defineI18nLocale(() => {
       next: 'Siguiente',
       formatDayAndDayInMonth: 'EEE d :',
       unknown: 'Horario indicativo',
+      eventRange: 'El {date} de {start} a {end}',
+      eventRangeOpenEnd: 'El {date} a partir de {start}',
       variableWeek: 'Los horarios pueden variar de una semana a otra.',
     },
     poiCard: {

--- a/locales/es-ES.ts
+++ b/locales/es-ES.ts
@@ -93,6 +93,7 @@ export default defineI18nLocale(() => {
       openAt: 'Abre',
       next: 'Siguiente',
       formatDayAndDayInMonth: 'EEE d :',
+      unknown: 'Horario indicativo',
       variableWeek: 'Los horarios pueden variar de una semana a otra.',
     },
     poiCard: {

--- a/locales/fr-FR.ts
+++ b/locales/fr-FR.ts
@@ -95,6 +95,8 @@ export default defineI18nLocale(() => {
       next: 'Prochain',
       formatDayAndDayInMonth: 'EEE d :',
       unknown: 'Horaires indicatifs',
+      eventRange: 'Le {date} de {start} à {end}',
+      eventRangeOpenEnd: 'Le {date} à partir de {start}',
       variableWeek: 'Les horaires peuvent varier d\'une semaine sur l\'autre.',
     },
     poiCard: {

--- a/locales/fr-FR.ts
+++ b/locales/fr-FR.ts
@@ -94,6 +94,7 @@ export default defineI18nLocale(() => {
       openAt: 'Ouverture',
       next: 'Prochain',
       formatDayAndDayInMonth: 'EEE d :',
+      unknown: 'Horaires indicatifs',
       variableWeek: 'Les horaires peuvent varier d\'une semaine sur l\'autre.',
     },
     poiCard: {


### PR DESCRIPTION
Closes #852

## Changes

**`components/Fields/OpeningHours.vue`**
- `nextChange` computed: `getUnknown()` + `getState()` → type `'opened' | 'openAt' | 'unknown'`
- Status block: `&& !isEvent` pour masquer sur événements ponctuels
- Nouveau branch `unknown` en amber
- `eventDisplay` computed via `getOpenIntervals()` pour Card mode + isEvent
- Card mode template: affiche `"Le {date} de {start} à {end}"` (ou `"à partir de {start}"` si open-end) au lieu de `prettifyValue()`

**`locales/{fr-FR,en-GB,es-ES}.ts`**
- `openingHours.unknown`
- `openingHours.eventRange`
- `openingHours.eventRangeOpenEnd`

## Behavior

| Valeur | Contexte | Avant | Après |
|---|---|---|---|
| `Aug 23 16:00+` (à 16h) | Default | "Actuellement fermé" (rouge) | "Horaires indicatifs" (amber) |
| `Nov 24 Tu 09:00-10:30` | Default | "Actuellement fermé - Ouverture..." + pretty | pretty seul |
| `Nov 24 Tu 09:00-10:30` | Card | "Nov. 24 Mar. 09:00-10:30" | "Le 24/11/2026 de 09h à 10h30" |
| `Aug 23 16:00+` | Card | `getComment()` anglais | "Le 23/08/2026 à partir de 16h" |
| Horaires normaux | tous | inchangé | inchangé |

> Note : le champ `start_end_date` devra être masqué en Card mode côté config API quand `opening_hours` couvre déjà la date (hors scope frontend).

## Test plan

- [ ] `Nov 24 Tu 09:00-10:30` Card → "Le 24/11/2026 de 09h à 10h30"
- [ ] `Aug 23 16:00+` Card → "Le 23/08/2026 à partir de 16h"
- [ ] `Aug 23 16:00+` Default → "Horaires indicatifs" (amber) à 16h
- [ ] `Nov 24 Tu 09:00-10:30` Default → plus de statut, pretty seul
- [ ] Horaires hebdomadaires normaux → comportement identique
- [ ] `yarn nuxi typecheck .` ✅ — `yarn lint:js` ✅