### PR TITLE
revert(OpeningHours): remove isEvent computed and related tests

### DIFF
--- a/components/Fields/OpeningHours.test.js
+++ b/components/Fields/OpeningHours.test.js
@@ -126,13 +126,3 @@ it('isEvent — non-event still shows variableWeek for variable schedules', () =
   )
   expect(hasVariableWeek).toBeTruthy()
 })
-
-it('isEvent — seasonal date range is not an event', () => {
-  // "Apr 1-Oct 31: ..." starts with "Apr " but is a seasonal schedule, not a one-time event
-  const wrapper = factory({ openingHours: 'Apr 1-Oct 31: Fr-Su 10:00-18:00' })
-  const paragraphs = [...wrapper.querySelectorAll('p')]
-  const hasVariableWeek = paragraphs.some(p =>
-    p.textContent?.includes('variabl'),
-  )
-  expect(hasVariableWeek).toBeTruthy()
-})

--- a/components/Fields/OpeningHours.test.js
+++ b/components/Fields/OpeningHours.test.js
@@ -100,17 +100,8 @@ it('pretty', () => {
   )
 })
 
-it('isEvent — suppresses variableWeek warning (year-prefixed)', () => {
+it('isEvent — suppresses variableWeek warning', () => {
   const wrapper = factory({ openingHours: '2025 Jan 25 20:30-22:00' })
-  const paragraphs = [...wrapper.querySelectorAll('p')]
-  const hasVariableWeek = paragraphs.some(p =>
-    p.textContent?.includes('variabl'),
-  )
-  expect(hasVariableWeek).toBeFalsy()
-})
-
-it('isEvent — suppresses variableWeek warning (month-prefixed, no year)', () => {
-  const wrapper = factory({ openingHours: 'Aug 04 18:00-23:00' })
   const paragraphs = [...wrapper.querySelectorAll('p')]
   const hasVariableWeek = paragraphs.some(p =>
     p.textContent?.includes('variabl'),

--- a/components/Fields/OpeningHours.test.js
+++ b/components/Fields/OpeningHours.test.js
@@ -99,21 +99,3 @@ it('pretty', () => {
     '<li>Dim.,PH 07:30-12:15</li>',
   )
 })
-
-it('isEvent — suppresses variableWeek warning', () => {
-  const wrapper = factory({ openingHours: '2025 Jan 25 20:30-22:00' })
-  const paragraphs = [...wrapper.querySelectorAll('p')]
-  const hasVariableWeek = paragraphs.some(p =>
-    p.textContent?.includes('variabl'),
-  )
-  expect(hasVariableWeek).toBeFalsy()
-})
-
-it('isEvent — non-event still shows variableWeek for variable schedules', () => {
-  const wrapper = factory({ openingHours: 'Apr-Oct: Fr-Su 10:00-18:00' })
-  const paragraphs = [...wrapper.querySelectorAll('p')]
-  const hasVariableWeek = paragraphs.some(p =>
-    p.textContent?.includes('variabl'),
-  )
-  expect(hasVariableWeek).toBeTruthy()
-})

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -41,7 +41,7 @@ const comment = computed(() => oh.value?.getComment(props.baseDate))
 const isCompact = computed(() => props.context === PropertyTranslationsContextEnum.Card)
 
 const isEvent = computed(() =>
-  /^(?:\d{4}\s|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2}(?:\s|$))/i.test(props.openingHours),
+  /^(?:\d{4}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s/i.test(props.openingHours),
 )
 
 const variable = computed(() => {

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -23,8 +23,7 @@ const props = withDefaults(defineProps<{
 //
 const siteStore = useSiteStore()
 const { settings } = siteStore
-const { locale } = useI18n()
-const { t } = useI18n()
+const { locale, t } = useI18n()
 
 const PointTime = ['collection_times'] as AssocRenderValue[]
 
@@ -64,7 +63,7 @@ const pretty = computed((): [string | undefined, string[]][] | undefined => {
             print_semicolon: false,
           },
         })
-        .replace(/(^\w|\s\w)/g, (c: any) => c.toUpperCase())
+        .replace(/(^\w|\s\w)/g, (c: string) => c.toUpperCase())
         .split('\n')
     }
     catch (e) {
@@ -79,12 +78,12 @@ const pretty = computed((): [string | undefined, string[]][] | undefined => {
       const ret: [string | undefined, string[]][] = []
       // Stable group by month
       prettyString
-        .map((row: any) => (
+        .map((row: string) => (
           row.includes(': ')
-            ? [row.slice(0, row.indexOf(': ')), row.slice(row.indexOf(': ') + 1 + 1)]
+            ? [row.slice(0, row.indexOf(': ')), row.slice(row.indexOf(': ') + 2)]
             : [undefined, row]
         ) as [string | undefined, string])
-        .forEach(([month, date]: any) => {
+        .forEach(([month, date]) => {
           const i = ret.findIndex(r => r[0] === month)
           if (i >= 0)
             ret[i][1].push(date)

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -23,7 +23,8 @@ const props = withDefaults(defineProps<{
 //
 const siteStore = useSiteStore()
 const { settings } = siteStore
-const { locale, t } = useI18n()
+const { locale } = useI18n()
+const { t } = useI18n()
 
 const PointTime = ['collection_times'] as AssocRenderValue[]
 
@@ -39,8 +40,6 @@ const oh = computed(() => OpeningHoursFactory())
 const comment = computed(() => oh.value?.getComment(props.baseDate))
 
 const isCompact = computed(() => props.context === PropertyTranslationsContextEnum.Card)
-
-const isEvent = computed(() => /^\d{4}\s/.test(props.openingHours))
 
 const variable = computed(() => {
   try {
@@ -65,7 +64,7 @@ const pretty = computed((): [string | undefined, string[]][] | undefined => {
             print_semicolon: false,
           },
         })
-        .replace(/(^\w|\s\w)/g, (c: string) => c.toUpperCase())
+        .replace(/(^\w|\s\w)/g, (c: any) => c.toUpperCase())
         .split('\n')
     }
     catch (e) {
@@ -80,12 +79,12 @@ const pretty = computed((): [string | undefined, string[]][] | undefined => {
       const ret: [string | undefined, string[]][] = []
       // Stable group by month
       prettyString
-        .map((row: string) => (
+        .map((row: any) => (
           row.includes(': ')
-            ? [row.slice(0, row.indexOf(': ')), row.slice(row.indexOf(': ') + 2)]
+            ? [row.slice(0, row.indexOf(': ')), row.slice(row.indexOf(': ') + 1 + 1)]
             : [undefined, row]
         ) as [string | undefined, string])
-        .forEach(([month, date]) => {
+        .forEach(([month, date]: any) => {
           const i = ret.findIndex(r => r[0] === month)
           if (i >= 0)
             ret[i][1].push(date)
@@ -217,7 +216,7 @@ function OpeningHoursFactory(): OpeningHours | undefined {
           </ul>
         </li>
       </ul>
-      <template v-if="variable && !isEvent">
+      <template v-if="variable">
         <p>{{ t('openingHours.variableWeek') }}</p>
       </template>
     </template>

--- a/components/Fields/OpeningHours.vue
+++ b/components/Fields/OpeningHours.vue
@@ -40,9 +40,7 @@ const comment = computed(() => oh.value?.getComment(props.baseDate))
 
 const isCompact = computed(() => props.context === PropertyTranslationsContextEnum.Card)
 
-const isEvent = computed(() =>
-  /^(?:\d{4}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s/i.test(props.openingHours),
-)
+const isEvent = computed(() => /^\d{4}\s/.test(props.openingHours))
 
 const variable = computed(() => {
   try {


### PR DESCRIPTION
Closes #855

## Context

Three commits introduced an `isEvent` computed in `OpeningHours.vue` that detected one-time or month-prefixed event strings via a regex heuristic (`4548b1df`, `f0df757e`, `df0d6935`). This approach is being dropped in favour of a proper API-side render type (`opening_hours:event`) that will carry the intent explicitly, removing the need for any frontend heuristic.

## Changes

- Revert `4548b1df` — removes `isEvent` computed and restores `variable` guard (variableWeek shown for all non-stable schedules)
- Revert `f0df757e` — removes month-prefix regex extension and associated tests
- Revert `df0d6935` — removes seasonal false-positive fix and associated tests
- Remove two leftover `isEvent` test descriptions auto-merged during revert

## Test plan

- [ ] `yarn nuxi typecheck .` ✅
- [ ] `yarn lint:js` ✅
- [ ] Regular weekly schedule (`Tu-Sa 07:00-19:00`) → comportement inchangé (status + pretty)
- [ ] Seasonal schedule (`Apr-Oct: Fr-Su 10:00-18:00`) → variableWeek warning toujours affiché