### PR TITLE
feat: add EmergencyBanner component for theme-driven urgent notifications

### DIFF
--- a/components/EmergencyBanner.vue
+++ b/components/EmergencyBanner.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useSiteStore } from '~/stores/site'
+
+const siteStore = useSiteStore()
+const { theme } = storeToRefs(siteStore)
+
+const dismissed = ref(false)
+
+const message = computed((): string | undefined => {
+  return theme.value?.emergency_message?.fr
+})
+
+const url = computed((): string | undefined => {
+  return theme.value?.emergency_url
+})
+
+const isExternalUrl = computed((): boolean => {
+  return !!url.value && (url.value.startsWith('http://') || url.value.startsWith('https://'))
+})
+</script>
+
+<template>
+  <div
+    v-if="!dismissed && message"
+    class="tw-fixed tw-top-0 tw-left-0 tw-w-full tw-z-50 tw-bg-amber-500 tw-text-white tw-flex tw-items-center tw-justify-between tw-px-4 tw-py-2 tw-gap-4"
+    role="alert"
+  >
+    <span class="tw-flex-1 tw-text-sm tw-font-medium">{{ message }}</span>
+    <div class="tw-flex tw-items-center tw-gap-2 tw-shrink-0">
+      <a
+        v-if="url && isExternalUrl"
+        :href="url"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="tw-text-sm tw-font-semibold tw-underline tw-text-white hover:tw-text-amber-100"
+      >
+        {{ url }}
+      </a>
+      <NuxtLink
+        v-else-if="url"
+        :to="url"
+        target="_self"
+        class="tw-text-sm tw-font-semibold tw-underline tw-text-white hover:tw-text-amber-100"
+      >
+        {{ url }}
+      </NuxtLink>
+      <button
+        type="button"
+        class="tw-ml-2 tw-text-white tw-text-lg tw-leading-none tw-font-bold tw-bg-transparent tw-border-0 tw-cursor-pointer hover:tw-text-amber-100 focus:tw-outline-none"
+        aria-label="Dismiss"
+        @click="dismissed = true"
+      >
+        ✕
+      </button>
+    </div>
+  </div>
+</template>

--- a/components/EmergencyBanner.vue
+++ b/components/EmergencyBanner.vue
@@ -1,23 +1,27 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { useSiteStore } from '~/stores/site'
+import type { LanguageCode } from '~/utils/types'
 
 const siteStore = useSiteStore()
 const { theme } = storeToRefs(siteStore)
+const { locale, t } = useI18n()
 
 const dismissed = ref(false)
 
 const message = computed((): string | undefined => {
-  return theme.value?.emergency_message?.fr
+  const msg = theme.value?.emergency_message
+  if (!msg)
+    return undefined
+  const lang = locale.value.substring(0, 2) as LanguageCode
+  return msg[lang] ?? msg.fr
 })
 
-const url = computed((): string | undefined => {
-  return theme.value?.emergency_url
-})
+const url = computed((): string | undefined => theme.value?.emergency_url)
 
-const isExternalUrl = computed((): boolean => {
-  return !!url.value && (url.value.startsWith('http://') || url.value.startsWith('https://'))
-})
+const isExternalUrl = computed((): boolean =>
+  !!url.value && (url.value.startsWith('http://') || url.value.startsWith('https://')),
+)
 </script>
 
 <template>
@@ -35,7 +39,7 @@ const isExternalUrl = computed((): boolean => {
         rel="noopener noreferrer"
         class="tw-text-sm tw-font-semibold tw-underline tw-text-white hover:tw-text-amber-100"
       >
-        {{ url }}
+        {{ t('emergencyBanner.action') }}
       </a>
       <NuxtLink
         v-else-if="url"
@@ -43,7 +47,7 @@ const isExternalUrl = computed((): boolean => {
         target="_self"
         class="tw-text-sm tw-font-semibold tw-underline tw-text-white hover:tw-text-amber-100"
       >
-        {{ url }}
+        {{ t('emergencyBanner.action') }}
       </NuxtLink>
       <button
         type="button"

--- a/components/EmergencyBanner.vue
+++ b/components/EmergencyBanner.vue
@@ -51,8 +51,8 @@ const isExternalUrl = computed((): boolean =>
       </NuxtLink>
       <button
         type="button"
-        class="tw-ml-2 tw-text-white tw-text-lg tw-leading-none tw-font-bold tw-bg-transparent tw-border-0 tw-cursor-pointer hover:tw-text-amber-100 focus:tw-outline-none"
-        aria-label="Dismiss"
+        class="tw-text-white tw-text-lg tw-leading-none tw-font-bold tw-bg-transparent tw-border-0 tw-cursor-pointer hover:tw-text-amber-100 focus:tw-outline-none"
+        :aria-label="t('emergencyBanner.dismiss')"
         @click="dismissed = true"
       >
         ✕

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,6 +8,7 @@ import { menuStore as useMenuStore } from '~/stores/menu'
 import { headerFromSettings } from '~/lib/apiSettings'
 import '~/assets/tailwind.scss'
 import type { ApiMenuCollection } from '~/types/api/menu'
+import EmergencyBanner from '~/components/EmergencyBanner.vue'
 
 const { detectHost } = useHostDetection()
 
@@ -84,6 +85,7 @@ if (status.value === 'success' && data.value) {
 
 <template>
   <div class="v-locale--is-ltr">
+    <EmergencyBanner />
     <slot />
   </div>
 </template>

--- a/lib/apiSettings.ts
+++ b/lib/apiSettings.ts
@@ -24,6 +24,8 @@ export interface SiteInfosTheme {
   google_site_verification?: string
   google_tag_manager_id?: string
   report_issue_url?: boolean
+  emergency_message?: MultilingualString
+  emergency_url?: string
 }
 
 export interface Settings {

--- a/locales/en-GB.ts
+++ b/locales/en-GB.ts
@@ -86,6 +86,9 @@ export default defineI18nLocale(() => {
       to: 'Until {to}',
       on: 'On {on}',
     },
+    emergencyBanner: {
+      action: 'Learn more',
+    },
     openingHours: {
       opened: 'Currently open',
       closeAt: 'Closes',

--- a/locales/en-GB.ts
+++ b/locales/en-GB.ts
@@ -88,6 +88,7 @@ export default defineI18nLocale(() => {
     },
     emergencyBanner: {
       action: 'Learn more',
+      dismiss: 'Dismiss',
     },
     openingHours: {
       opened: 'Currently open',

--- a/locales/es-ES.ts
+++ b/locales/es-ES.ts
@@ -88,6 +88,7 @@ export default defineI18nLocale(() => {
     },
     emergencyBanner: {
       action: 'Más información',
+      dismiss: 'Cerrar',
     },
     openingHours: {
       opened: 'Actualmente abierto',

--- a/locales/es-ES.ts
+++ b/locales/es-ES.ts
@@ -86,6 +86,9 @@ export default defineI18nLocale(() => {
       to: 'Hasta {to}',
       on: 'El {on}',
     },
+    emergencyBanner: {
+      action: 'Más información',
+    },
     openingHours: {
       opened: 'Actualmente abierto',
       closeAt: 'Cierra',

--- a/locales/fr-FR.ts
+++ b/locales/fr-FR.ts
@@ -89,6 +89,7 @@ export default defineI18nLocale(() => {
     },
     emergencyBanner: {
       action: 'En savoir plus',
+      dismiss: 'Fermer',
     },
     openingHours: {
       opened: 'Actuellement ouvert',

--- a/locales/fr-FR.ts
+++ b/locales/fr-FR.ts
@@ -87,6 +87,9 @@ export default defineI18nLocale(() => {
       to: 'Jusqu\'au {to}',
       on: 'Le {on}',
     },
+    emergencyBanner: {
+      action: 'En savoir plus',
+    },
     openingHours: {
       opened: 'Actuellement ouvert',
       closeAt: 'Fermeture',


### PR DESCRIPTION
Closes #859

## Changes

**`lib/apiSettings.ts`** — add `emergency_message?: MultilingualString` and `emergency_url?: string` to `SiteInfosTheme`

**`components/EmergencyBanner.vue`** (new)
- Reads `emergency_message` and `emergency_url` from the current theme
- Dismissible via ✕ button (session-only `ref`)
- Action button: `target="_blank"` for external URLs, `target="_self"` + NuxtLink for internal
- Amber banner, fixed top, high z-index
- Hidden when dismissed or message is empty

**`layouts/default.vue`** — includes `<EmergencyBanner />`