### PR TITLE
fix: null/type guards for Phone, Filters/Select, SelectedCategories and NaN POI ID

### DIFF
--- a/components/Fields/Phone.vue
+++ b/components/Fields/Phone.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 const device = useDevice()
 
 const numberFormated = computed((): string => {
-  return props.number.replaceAll(' ', ' ')
+  return String(props.number).replaceAll(' ', ' ')
 })
 </script>
 

--- a/components/Filters/Select.vue
+++ b/components/Filters/Select.vue
@@ -17,7 +17,7 @@ const currentValue = ref(props.filter.filterValues)
 
 const items = computed((): { title: string, value: string }[] => {
   return props.filter.def.values.map(value => ({
-    title: (value.name && value.name.fr) || value.value,
+    title: String((value.name && value.name.fr) || value.value),
     value: value.value,
   })).sort((a, b) => a.title.localeCompare(b.title, locale.value, { sensitivity: 'base' }))
 })

--- a/components/Home/SelectedCategories.vue
+++ b/components/Home/SelectedCategories.vue
@@ -19,6 +19,9 @@ const menuStore = useMenuStore()
 
 function getTeritorioIconBadgeProps(item: MenuCategory) {
   const base = item.category
+  if (!base)
+    return { id: item.id, picto: '', colorFill: '', colorText: '', size: 'lg' as const }
+
   const { colorFill, colorText } = useContrastedColors(base.color_fill)
 
   return {
@@ -42,8 +45,8 @@ function getTeritorioIconBadgeProps(item: MenuCategory) {
           v-for="category in categories"
           :key="category.id"
           :data-testid="`selected-category-${category.id}`"
-          :aria-label="`${$t('headerMenu.disableCategory')}: ${category.category.name.fr}`"
-          :title="`${$t('headerMenu.disableCategory')}: ${category.category.name.fr}`"
+          :aria-label="`${$t('headerMenu.disableCategory')}: ${category.category?.name?.fr}`"
+          :title="`${$t('headerMenu.disableCategory')}: ${category.category?.name?.fr}`"
           icon
           width="40px"
           height="40px"

--- a/components/Home/SelectedCategories.vue
+++ b/components/Home/SelectedCategories.vue
@@ -19,8 +19,11 @@ const menuStore = useMenuStore()
 
 function getTeritorioIconBadgeProps(item: MenuCategory) {
   const base = item.category
-  if (!base)
+  if (!base) {
+    if (import.meta.dev)
+      console.warn(`[SelectedCategories] category.category is undefined for item ${item.id}`)
     return { id: item.id, picto: '', colorFill: '', colorText: '', size: 'lg' as const }
+  }
 
   const { colorFill, colorText } = useContrastedColors(base.color_fill)
 
@@ -45,8 +48,8 @@ function getTeritorioIconBadgeProps(item: MenuCategory) {
           v-for="category in categories"
           :key="category.id"
           :data-testid="`selected-category-${category.id}`"
-          :aria-label="`${$t('headerMenu.disableCategory')}: ${category.category?.name?.fr}`"
-          :title="`${$t('headerMenu.disableCategory')}: ${category.category?.name?.fr}`"
+          :aria-label="`${$t('headerMenu.disableCategory')}: ${category.category?.name?.fr ?? ''}`"
+          :title="`${$t('headerMenu.disableCategory')}: ${category.category?.name?.fr ?? ''}`"
           icon
           width="40px"
           height="40px"

--- a/pages/pois/[ids]/map.vue
+++ b/pages/pois/[ids]/map.vue
@@ -54,7 +54,7 @@ const { data, error } = await useAsyncData('pois-map', async () => {
   )
 
   const depsResults = await Promise.allSettled(
-    poiIdsAsNumbers.value.map(poiId =>
+    poiIds.value.map(poiId =>
       $fetch<ApiPoiDepsCollection>(
         `${apiEndpoint.value}/poi/${poiId}/deps.geojson`,
         {
@@ -88,7 +88,7 @@ const { data, error } = await useAsyncData('pois-map', async () => {
 
     const deps = depsResults.flatMap((result, index) => {
       if (result.status === 'rejected') {
-        captureMessage(`Failed to fetch deps for POI ${poiIdsAsNumbers.value[index]}: ${result.reason}`, 'warning')
+        captureMessage(`Failed to fetch deps for POI ${poiIds.value[index]}: ${result.reason}`, 'warning')
         return []
       }
 


### PR DESCRIPTION
Fixes four data-safety bugs surfaced by Sentry. All changes are defensive guards against API data that doesn't match the declared TypeScript types at runtime.

## Changes

- **`Fields/Phone.vue`** — wrap `props.number` with `String()` before `replaceAll`. The prop is typed as `string` but receives numbers at runtime on some devices (Sentry VIDO-1AD).
- **`Filters/Select.vue`** — wrap computed `title` with `String()` to ensure `localeCompare` never receives a non-string value when the API returns a number for `value.value` (Sentry VIDO-17E).
- **`Home/SelectedCategories.vue`** — add optional chaining (`?.`) on `category.category` in template attributes, and an early return guard in `getTeritorioIconBadgeProps` when `category` is `undefined` at runtime due to `MenuItem` union type mismatch (Sentry VIDO-134).
- **`pois/[ids]/map.vue`** — use original string POI IDs for the deps fetch URL and Sentry message instead of `Number()` conversion, which produces `NaN` for `ref:`-prefixed IDs and results in `/poi/NaN/deps.geojson` 404s (Sentry VIDO-13Z).

## Test plan

- [ ] Navigate to a POI detail page with a phone number field — no crash
- [ ] Open a filter with a list of values — autocomplete renders without crash
- [ ] Verify selected categories badge renders without crash when categories are loaded
- [ ] Navigate to `/pois/ref:sirtaqui:XXXX/map` — no NaN in Sentry, no 404 on deps URL

Closes #863